### PR TITLE
feat: 로그인 전체 시트 페이지 퍼블리싱 (#7)

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -5,7 +5,9 @@ import SwiftUI
 struct HopesApp: App {
     var body: some Scene {
         WindowGroup {
-            LoginSwipeGuideView()
+            LoginFlowView(
+                isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login")
+            )
         }
     }
 }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+public struct LoginFlowView: View {
+    @State private var isLoginOpen = false
+    @State private var email = ""
+    @State private var password = ""
+
+    private let onLogin: () -> Void
+    private let onSignUp: () -> Void
+
+    public init(
+        isLoginInitiallyOpen: Bool = false,
+        onLogin: @escaping () -> Void = {},
+        onSignUp: @escaping () -> Void = {}
+    ) {
+        _isLoginOpen = State(initialValue: isLoginInitiallyOpen)
+        self.onLogin = onLogin
+        self.onSignUp = onSignUp
+    }
+
+    public var body: some View {
+        ZStack {
+            if isLoginOpen {
+                LoginView(
+                    email: $email,
+                    password: $password,
+                    onLogin: onLogin,
+                    onSignUp: onSignUp
+                )
+                .transition(.move(edge: .bottom))
+            } else {
+                LoginSwipeGuideView {
+                    withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
+                        isLoginOpen = true
+                    }
+                }
+                .transition(.opacity)
+            }
+        }
+    }
+}
+
+#Preview("로그인 플로우") {
+    LoginFlowView()
+        .frame(width: 402, height: 874)
+}

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+public struct LoginView: View {
+    @Binding private var email: String
+    @Binding private var password: String
+
+    private let onLogin: () -> Void
+    private let onSignUp: () -> Void
+
+    public init(
+        email: Binding<String>,
+        password: Binding<String>,
+        onLogin: @escaping () -> Void = {},
+        onSignUp: @escaping () -> Void = {}
+    ) {
+        _email = email
+        _password = password
+        self.onLogin = onLogin
+        self.onSignUp = onSignUp
+    }
+
+    public var body: some View {
+        ZStack {
+            Color.hopesHeroGradient
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                HopesLogo(placement: .onBrand)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 14)
+                    .padding(.horizontal, 32)
+
+                Text("선배에게 묻는\n가장 솔직한\n학교 이야기")
+                    .font(.system(size: 31, weight: .bold))
+                    .foregroundStyle(.white)
+                    .lineSpacing(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 32)
+                    .padding(.top, 168)
+
+                Spacer(minLength: 0)
+            }
+
+            VStack(spacing: 0) {
+                Spacer(minLength: 0)
+                loginSheet
+            }
+            .ignoresSafeArea(edges: .bottom)
+        }
+    }
+
+    private var loginSheet: some View {
+        ZStack(alignment: .top) {
+            Capsule()
+                .fill(Color("HopesSheetHandle", bundle: .module))
+                .frame(width: 86, height: 5)
+                .padding(.top, 20)
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text("로그인")
+                    .font(.system(size: 26, weight: .bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("학교 이메일로 로그인하고 바로 질문을 시작하세요.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(Color.hopesTextSecondary)
+                    .padding(.top, 4)
+
+                Text("이메일")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .padding(.top, 42)
+
+                TextField("", text: $email)
+                    .hopesEmailInputTraits()
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .padding(.horizontal, 13)
+                    .frame(height: 40)
+                    .background(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255))
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .padding(.horizontal, 3)
+                    .padding(.top, 12)
+                    .accessibilityLabel("이메일")
+
+                Text("비밀번호")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .padding(.top, 18)
+
+                SecureField("", text: $password)
+                    .hopesPasswordInputTraits()
+                    .font(.system(size: 15))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .padding(.horizontal, 16)
+                    .frame(height: 52)
+                    .overlay(alignment: .top) {
+                        Rectangle()
+                            .fill(Color.hopesBorder)
+                            .frame(height: 1)
+                    }
+                    .padding(.top, 10)
+                    .accessibilityLabel("비밀번호")
+            }
+            .padding(.horizontal, 32)
+            .padding(.top, 110)
+
+            HopesButton("로그인", action: onLogin)
+                .padding(.horizontal, 32)
+                .padding(.top, 355)
+
+            Button(action: onSignUp) {
+                Text("계정이 없으신가요?  회원가입")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(Color.hopesTextSecondary)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 32)
+            .padding(.top, 419)
+        }
+        .frame(height: 502, alignment: .top)
+        .frame(maxWidth: .infinity)
+        .background(.white)
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: 28,
+                topTrailingRadius: 28
+            )
+        )
+        .shadow(
+            color: Color(red: 13 / 255, green: 26 / 255, blue: 46 / 255).opacity(0.12),
+            radius: 16,
+            y: 7
+        )
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func hopesEmailInputTraits() -> some View {
+        #if os(iOS)
+        textInputAutocapitalization(.never)
+            .keyboardType(.emailAddress)
+            .textContentType(.username)
+        #else
+        self
+        #endif
+    }
+
+    @ViewBuilder
+    func hopesPasswordInputTraits() -> some View {
+        #if os(iOS)
+        textContentType(.password)
+        #else
+        self
+        #endif
+    }
+}
+
+#Preview("로그인 전체 시트") {
+    @Previewable @State var email = ""
+    @Previewable @State var password = ""
+
+    LoginView(
+        email: $email,
+        password: $password
+    )
+    .frame(width: 402, height: 874)
+}

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -123,3 +123,14 @@ func loginSwipeGuideCanBeConstructed() {
     _ = LoginSwipeGuideView()
     _ = LoginSwipeGuideView(onOpenLogin: {})
 }
+
+@Test
+@MainActor
+func loginViewsCanBeConstructed() {
+    _ = LoginView(
+        email: .constant(""),
+        password: .constant("")
+    )
+    _ = LoginFlowView()
+    _ = LoginFlowView(isLoginInitiallyOpen: true)
+}


### PR DESCRIPTION
## 📌 변경사항
 - 이메일·비밀번호 실제 입력 가능
  - 로그인·회원가입 버튼 동작 콜백 제공
  - 안내 화면에서 스와이프 또는 열기를 누르면 로그인 화면으로 전환
  - Xcode iPhone 17 Pro 빌드·실행 성공


## 📷 스크린샷
<img width="452" height="970" alt="스크린샷 2026-07-25 오전 5 52 00" src="https://github.com/user-attachments/assets/70bff1c4-9a6e-4bc9-999e-caf5975ee04f" />



## 🔗 관련 이슈

close #7 

## 💬 참고사항
없음

