### PR TITLE
feat: [#9] 회원가입 페이지 퍼블리싱

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -6,7 +6,8 @@ struct HopesApp: App {
     var body: some Scene {
         WindowGroup {
             LoginFlowView(
-                isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login")
+                isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login"),
+                isSignUpInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-sign-up")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -1,41 +1,81 @@
 import SwiftUI
 
 public struct LoginFlowView: View {
-    @State private var isLoginOpen = false
+    private enum Screen {
+        case guide
+        case login
+        case signUp
+    }
+
+    @State private var screen: Screen
     @State private var email = ""
     @State private var password = ""
+    @State private var signUpEmail = ""
+    @State private var name = ""
+    @State private var major = ""
+    @State private var cohort = ""
 
     private let onLogin: () -> Void
-    private let onSignUp: () -> Void
+    private let onSignUp: (SignUpFormData) -> Void
 
     public init(
         isLoginInitiallyOpen: Bool = false,
+        isSignUpInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
-        onSignUp: @escaping () -> Void = {}
+        onSignUp: @escaping (SignUpFormData) -> Void = { _ in }
     ) {
-        _isLoginOpen = State(initialValue: isLoginInitiallyOpen)
+        let initialScreen: Screen = if isSignUpInitiallyOpen {
+            .signUp
+        } else if isLoginInitiallyOpen {
+            .login
+        } else {
+            .guide
+        }
+
+        _screen = State(initialValue: initialScreen)
         self.onLogin = onLogin
         self.onSignUp = onSignUp
     }
 
     public var body: some View {
         ZStack {
-            if isLoginOpen {
+            switch screen {
+            case .guide:
+                LoginSwipeGuideView {
+                    transition(to: .login)
+                }
+                .transition(.opacity)
+
+            case .login:
                 LoginView(
                     email: $email,
                     password: $password,
                     onLogin: onLogin,
-                    onSignUp: onSignUp
+                    onSignUp: {
+                        transition(to: .signUp)
+                    }
                 )
                 .transition(.move(edge: .bottom))
-            } else {
-                LoginSwipeGuideView {
-                    withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
-                        isLoginOpen = true
+
+            case .signUp:
+                SignUpView(
+                    email: $signUpEmail,
+                    name: $name,
+                    major: $major,
+                    cohort: $cohort,
+                    onSignUp: onSignUp,
+                    onGoToLogin: {
+                        transition(to: .login)
                     }
-                }
-                .transition(.opacity)
+                )
+                .transition(.move(edge: .trailing))
             }
+        }
+    }
+
+    private func transition(to screen: Screen) {
+        withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
+            self.screen = screen
         }
     }
 }

--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -1,0 +1,279 @@
+import SwiftUI
+
+public struct SignUpFormData: Equatable, Sendable {
+    public var email: String
+    public var name: String
+    public var major: String
+    public var cohort: String
+
+    public init(
+        email: String,
+        name: String,
+        major: String,
+        cohort: String
+    ) {
+        self.email = email
+        self.name = name
+        self.major = major
+        self.cohort = cohort
+    }
+}
+
+public struct SignUpView: View {
+    @Binding private var email: String
+    @Binding private var name: String
+    @Binding private var major: String
+    @Binding private var cohort: String
+
+    private let onSignUp: (SignUpFormData) -> Void
+    private let onGoToLogin: () -> Void
+
+    public init(
+        email: Binding<String>,
+        name: Binding<String>,
+        major: Binding<String>,
+        cohort: Binding<String>,
+        onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
+        onGoToLogin: @escaping () -> Void = {}
+    ) {
+        _email = email
+        _name = name
+        _major = major
+        _cohort = cohort
+        self.onSignUp = onSignUp
+        self.onGoToLogin = onGoToLogin
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+                .ignoresSafeArea()
+
+            header
+            formCard
+                .padding(.top, 217)
+
+            signUpButton
+                .padding(.top, 579)
+
+            HopesButton(
+                "이미 계정이 있어요",
+                variant: .secondary,
+                width: .fixed(354),
+                action: onGoToLogin
+            )
+            .padding(.top, 645)
+
+            authTabBar
+                .frame(maxHeight: .infinity, alignment: .bottom)
+                .ignoresSafeArea(edges: .bottom)
+        }
+    }
+
+    private var header: some View {
+        ZStack(alignment: .topLeading) {
+            Color.hopesHeroGradient
+
+            HopesLogo(placement: .onBrand)
+                .padding(.leading, 32)
+                .padding(.top, 76)
+
+            Text("학교 이메일로\n간단히 시작하기")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(.white)
+                .lineSpacing(1)
+                .padding(.leading, 32)
+                .padding(.top, 154)
+        }
+        .frame(height: 250)
+        .ignoresSafeArea(edges: .top)
+    }
+
+    private var formCard: some View {
+        VStack(spacing: 0) {
+            signUpField(
+                "학교 이메일",
+                text: $email,
+                placeholder: "s26055@gsm.hs.kr",
+                kind: .email
+            )
+            signUpField(
+                "이름",
+                text: $name,
+                placeholder: "임서하"
+            )
+            signUpField(
+                "전공",
+                text: $major,
+                placeholder: ""
+            )
+            signUpField(
+                "기수",
+                text: $cohort,
+                placeholder: "10기",
+                kind: .cohort
+            )
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 22)
+        .frame(width: 354, height: 338, alignment: .top)
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+        .shadow(color: Color(red: 13 / 255, green: 26 / 255, blue: 46 / 255).opacity(0.09), radius: 11, y: 8)
+    }
+
+    private var signUpButton: some View {
+        Button {
+            onSignUp(
+                SignUpFormData(
+                    email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+                    name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+                    major: major.trimmingCharacters(in: .whitespacesAndNewlines),
+                    cohort: cohort.trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+            )
+        } label: {
+            Text("회원가입")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 354, height: 46)
+                .background(isFormValid ? Color.hopesBrandPrimary : .clear)
+                .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isFormValid)
+        .accessibilityHint(isFormValid ? "" : "모든 항목을 올바르게 입력해 주세요.")
+    }
+
+    private var authTabBar: some View {
+        HStack(spacing: 0) {
+            authTabItem("홈", symbol: "●", isSelected: true)
+            authTabItem("채팅", symbol: "○")
+            authTabItem("기록", symbol: "○")
+            authTabItem("설정", symbol: "○")
+        }
+        .frame(height: 84)
+        .frame(maxWidth: .infinity)
+        .background(.white)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.hopesBorder)
+                .frame(height: 1)
+        }
+    }
+
+    private func authTabItem(
+        _ title: String,
+        symbol: String,
+        isSelected: Bool = false
+    ) -> some View {
+        VStack(spacing: 5) {
+            Text(symbol)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(
+                    isSelected ? Color.hopesBrandPrimary : Color.hopesTextPlaceholder
+                )
+                .frame(width: 60, height: 30)
+                .background(isSelected ? Color.hopesBrandTint : .clear)
+                .clipShape(Capsule())
+
+            Text(title)
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundStyle(
+                    isSelected ? Color.hopesBrandPrimary : Color.hopesTextSecondary
+                )
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 12)
+    }
+
+    private func signUpField(
+        _ title: String,
+        text: Binding<String>,
+        placeholder: String,
+        kind: SignUpFieldKind = .plain
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.hopesTextPrimary)
+
+            TextField(
+                "",
+                text: text,
+                prompt: Text(placeholder)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            )
+                .signUpInputTraits(kind)
+                .textFieldStyle(.plain)
+                .font(.system(size: 15))
+                .foregroundStyle(Color.hopesTextPrimary)
+                .padding(.horizontal, 16)
+                .frame(height: 52)
+                .overlay(alignment: .top) {
+                    Rectangle()
+                        .fill(Color.hopesBorder)
+                        .frame(height: 1)
+                }
+        }
+        .frame(height: 76, alignment: .top)
+    }
+
+    private var isFormValid: Bool {
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasSchoolDomain = trimmedEmail.range(
+            of: #"^[A-Z0-9._%+-]+@gsm\.hs\.kr$"#,
+            options: [.regularExpression, .caseInsensitive]
+        ) != nil
+
+        return hasSchoolDomain
+            && !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !major.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && cohort.rangeOfCharacter(from: .decimalDigits) != nil
+    }
+}
+
+private enum SignUpFieldKind {
+    case plain
+    case email
+    case cohort
+}
+
+private extension View {
+    @ViewBuilder
+    func signUpInputTraits(_ kind: SignUpFieldKind) -> some View {
+        #if os(iOS)
+        switch kind {
+        case .plain:
+            textInputAutocapitalization(.never)
+        case .email:
+            textInputAutocapitalization(.never)
+                .keyboardType(.emailAddress)
+                .textContentType(.emailAddress)
+        case .cohort:
+            keyboardType(.numbersAndPunctuation)
+        }
+        #else
+        self
+        #endif
+    }
+}
+
+#Preview("회원가입") {
+    @Previewable @State var email = ""
+    @Previewable @State var name = ""
+    @Previewable @State var major = ""
+    @Previewable @State var cohort = ""
+
+    SignUpView(
+        email: $email,
+        name: $name,
+        major: $major,
+        cohort: $cohort
+    )
+    .frame(width: 402, height: 874)
+}

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -133,4 +133,16 @@ func loginViewsCanBeConstructed() {
     )
     _ = LoginFlowView()
     _ = LoginFlowView(isLoginInitiallyOpen: true)
+    _ = LoginFlowView(isSignUpInitiallyOpen: true)
+}
+
+@Test
+@MainActor
+func signUpViewCanBeConstructed() {
+    _ = SignUpView(
+        email: .constant("s26055@gsm.hs.kr"),
+        name: .constant("임서하"),
+        major: .constant("소프트웨어개발과"),
+        cohort: .constant("10기")
+    )
 }


### PR DESCRIPTION
## 📌 변경사항
  - 학교 이메일: 이메일 키보드, @gsm.hs.kr 형식 검증
  - 이름·전공: 실제 텍스트 입력
  - 기수: 숫자 키보드 및 숫자 포함 검증
  - 모든 값이 유효해야 회원가입 버튼 활성화
  - 로그인 화면의 회원가입 → 회원가입 화면 전환
  - 이미 계정이 있어요 → 로그인 화면 복귀
  - 런타임에서 편집 가능한 TextField 4개 확인
  - iPhone 17 Pro 빌드·실행 성공



## 📷 스크린샷
<img width="442" height="1015" alt="스크린샷 2026-07-25 오전 5 55 56" src="https://github.com/user-attachments/assets/b23d65c0-1c92-46af-a5ed-168fad8886c7" />



## 🔗 관련 이슈

close #9 

## 💬 참고사항
없음


