### PR TITLE
feat: [#13] 채팅 홈 퍼블리싱

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -8,7 +8,8 @@ struct HopesApp: App {
             LoginFlowView(
                 isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login"),
                 isSignUpInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-sign-up"),
-                isOnboardingInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-onboarding")
+                isOnboardingInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-onboarding"),
+                isChatHomeInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-home")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Components/HopesButton.swift
+++ b/Sources/HopesDesignSystem/Components/HopesButton.swift
@@ -40,7 +40,7 @@ public struct HopesButton: View {
             case .small:
                 14
             case .medium:
-                21
+                12
             case .regular, .large, .extraLarge:
                 20
             }
@@ -106,6 +106,7 @@ public struct HopesButton: View {
     public var body: some View {
         Button(title, action: action)
             .font(size.font)
+            .lineLimit(1)
             .foregroundStyle(foregroundColor)
             .padding(.horizontal, size.horizontalPadding)
             .frame(

--- a/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+public struct ChatHomeView: View {
+    @State private var selectedTab: HopesTab = .chat
+    @Binding private var message: String
+
+    private let onNewChat: () -> Void
+    private let onSend: (String) -> Void
+
+    private let suggestions = [
+        ("⌂", "기숙사 하루 일과가 어떻게 돼?"),
+        ("◇", "입학하려면 뭘 준비해야 해?"),
+        ("<>", "전공 선택은 어떻게 하는 게 좋아?"),
+        ("□", "후배한테 해주고 싶은 조언 있어?"),
+    ]
+
+    public init(
+        message: Binding<String>,
+        onNewChat: @escaping () -> Void = {},
+        onSend: @escaping (String) -> Void = { _ in }
+    ) {
+        _message = message
+        self.onNewChat = onNewChat
+        self.onSend = onSend
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+
+            header
+                .padding(.horizontal, 24)
+                .padding(.top, 72)
+
+            HopesLogo(size: .large)
+                .padding(.top, 184)
+
+            VStack(spacing: 7) {
+                Text("무엇이 궁금한가요?")
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("광주소프트웨어마이스터고 선배에게 편하게 물어보세요.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesTextSecondary)
+                    .multilineTextAlignment(.center)
+                    .frame(width: 318)
+            }
+            .padding(.top, 283)
+
+            VStack(spacing: 14) {
+                ForEach(suggestions, id: \.1) { icon, title in
+                    HopesQuestionCard(title: title) {
+                        message = title
+                    } icon: {
+                        Text(icon)
+                    }
+                }
+            }
+            .padding(.horizontal, 24)
+            .padding(.top, 396)
+
+            composer
+                .padding(.horizontal, 24)
+                .padding(.top, 728)
+
+            HopesTabBar(selection: $selectedTab)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        HStack {
+            HopesLogo()
+
+            Spacer()
+
+            HopesButton(
+                "새 대화",
+                variant: .secondary,
+                size: .medium,
+                width: .fixed(78)
+            ) {
+                message = ""
+                onNewChat()
+            }
+        }
+    }
+
+    private var composer: some View {
+        HStack(spacing: 8) {
+            TextField("선배에게 메시지 보내기...", text: $message)
+                .font(.footnote)
+                .foregroundStyle(Color.hopesTextPrimary)
+                .onSubmit(sendMessage)
+
+            Button(action: sendMessage) {
+                Image(systemName: "arrow.up")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 38, height: 38)
+                    .background(Color.hopesBrandPrimary)
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: HopesMetrics.controlCornerRadius
+                        )
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("메시지 보내기")
+        }
+        .padding(.leading, 20)
+        .padding(.trailing, 14)
+        .frame(height: 52)
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
+        .overlay {
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+        .shadow(
+            color: Color(red: 13 / 255, green: 26 / 255, blue: 46 / 255)
+                .opacity(0.07),
+            radius: 8,
+            y: 6
+        )
+    }
+
+    private var trimmedMessage: String {
+        message.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func sendMessage() {
+        guard !trimmedMessage.isEmpty else {
+            return
+        }
+
+        onSend(trimmedMessage)
+    }
+}
+
+#Preview("채팅 홈") {
+    @Previewable @State var message = ""
+
+    ChatHomeView(message: $message)
+        .frame(width: 402, height: 874)
+}

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -6,6 +6,7 @@ public struct LoginFlowView: View {
         case login
         case signUp
         case onboarding
+        case chatHome
     }
 
     @State private var screen: Screen
@@ -15,6 +16,7 @@ public struct LoginFlowView: View {
     @State private var name = ""
     @State private var major = ""
     @State private var cohort = ""
+    @State private var chatMessage = ""
 
     private let onLogin: () -> Void
     private let onSignUp: (SignUpFormData) -> Void
@@ -24,11 +26,14 @@ public struct LoginFlowView: View {
         isLoginInitiallyOpen: Bool = false,
         isSignUpInitiallyOpen: Bool = false,
         isOnboardingInitiallyOpen: Bool = false,
+        isChatHomeInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
         onStartChat: @escaping () -> Void = {}
     ) {
-        let initialScreen: Screen = if isOnboardingInitiallyOpen {
+        let initialScreen: Screen = if isChatHomeInitiallyOpen {
+            .chatHome
+        } else if isOnboardingInitiallyOpen {
             .onboarding
         } else if isSignUpInitiallyOpen {
             .signUp
@@ -81,7 +86,14 @@ public struct LoginFlowView: View {
                 .transition(.move(edge: .trailing))
 
             case .onboarding:
-                OnboardingView(onStartChat: onStartChat)
+                OnboardingView {
+                    onStartChat()
+                    transition(to: .chatHome)
+                }
+                    .transition(.move(edge: .trailing))
+
+            case .chatHome:
+                ChatHomeView(message: $chatMessage)
                     .transition(.move(edge: .trailing))
             }
         }

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -156,3 +156,15 @@ func onboardingViewCanBeConstructed() {
     _ = OnboardingView(onStartChat: {})
     _ = HopesTabBar(selection: .constant(.home))
 }
+
+@Test
+@MainActor
+func chatHomeViewCanBeConstructed() {
+    _ = ChatHomeView(message: .constant(""))
+    _ = ChatHomeView(
+        message: .constant("기숙사 하루 일과가 어떻게 돼?"),
+        onNewChat: {},
+        onSend: { _ in }
+    )
+    _ = LoginFlowView(isChatHomeInitiallyOpen: true)
+}


### PR DESCRIPTION
## 📌 변경사항
  - 피그마 03 채팅 홈 프레임 기준으로 배치
  - 공용 로고·질문 카드·버튼·탭바 재사용
  - 추천 질문 선택 시 입력창에 실제 반영
  - 메시지 입력 및 전송 콜백 연결
  - 새 대화 버튼으로 입력 초기화
  - 온보딩의 채팅 시작하기에서 채팅 홈으로 이동
  - iPhone 17 Pro 빌드 및 화면 비교 완료


## 📷 스크린샷
<img width="473" height="988" alt="스크린샷 2026-07-25 오전 7 26 35" src="https://github.com/user-attachments/assets/9a4b8af8-0219-4652-90bd-11e88b1da233" />



## 🔗 관련 이슈

close #13 

## 💬 참고사항
없음

