### PR TITLE
feat: 지난 대화 퍼블리싱

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -11,7 +11,8 @@ struct HopesApp: App {
                 isOnboardingInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-onboarding"),
                 isChatHomeInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-home"),
                 isChatDetailInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-detail"),
-                isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence")
+                isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence"),
+                isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+
+public struct ConversationHistoryView: View {
+    public struct Conversation: Identifiable, Sendable {
+        public enum Period: Sendable {
+            case recent
+            case older
+        }
+
+        public let id: String
+        public let title: String
+        public let period: Period
+
+        public init(title: String, period: Period) {
+            id = title
+            self.title = title
+            self.period = period
+        }
+    }
+
+    @State private var selectedTab: HopesTab = .history
+    @State private var query = ""
+    @FocusState private var isSearchFocused: Bool
+
+    private let conversations: [Conversation]
+    private let onNewConversation: () -> Void
+    private let onSelectConversation: (Conversation) -> Void
+
+    public init(
+        conversations: [Conversation] = Self.sampleConversations,
+        onNewConversation: @escaping () -> Void = {},
+        onSelectConversation: @escaping (Conversation) -> Void = { _ in }
+    ) {
+        self.conversations = conversations
+        self.onNewConversation = onNewConversation
+        self.onSelectConversation = onSelectConversation
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+
+            header
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 76)
+
+            HopesButton(
+                "+  새 대화 시작",
+                variant: .secondary,
+                size: .large,
+                action: onNewConversation
+            )
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.top, 144)
+
+            searchBar
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 208)
+
+            conversationList
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 282)
+
+            HopesTabBar(selection: $selectedTab)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("지난 대화")
+                    .font(.system(size: 27, weight: .bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("웹사이트 구성을 리스트로 정리했어요.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            }
+
+            Spacer()
+
+            HopesButton(
+                "검색",
+                variant: .secondary,
+                size: .small,
+                width: .fixed(54)
+            ) {
+                isSearchFocused = true
+            }
+        }
+    }
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            TextField("지난 대화 검색", text: $query)
+                .font(.footnote)
+                .foregroundStyle(Color.hopesTextPrimary)
+                .padding(.horizontal, 20)
+                .frame(height: 44)
+                .background(.white)
+                .clipShape(
+                    RoundedRectangle(
+                        cornerRadius: HopesMetrics.controlCornerRadius
+                    )
+                )
+                .overlay {
+                    RoundedRectangle(
+                        cornerRadius: HopesMetrics.controlCornerRadius
+                    )
+                    .stroke(Color.hopesBorder, lineWidth: 1)
+                }
+                .focused($isSearchFocused)
+                .submitLabel(.search)
+
+            Button {
+                isSearchFocused = true
+            } label: {
+                Text("⌕")
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .frame(width: 52, height: 44)
+                    .background(.white)
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: HopesMetrics.controlCornerRadius
+                        )
+                    )
+                    .overlay {
+                        RoundedRectangle(
+                            cornerRadius: HopesMetrics.controlCornerRadius
+                        )
+                        .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("지난 대화 검색")
+        }
+    }
+
+    private var conversationList: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 0) {
+                conversationSection(
+                    title: "지난 7일",
+                    conversations: filteredConversations(for: .recent)
+                )
+
+                conversationSection(
+                    title: "이전",
+                    conversations: filteredConversations(for: .older)
+                )
+                .padding(.top, 20)
+            }
+        }
+        .scrollIndicators(.hidden)
+        .frame(height: 420)
+    }
+
+    private func conversationSection(
+        title: String,
+        conversations: [Conversation]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .font(.footnote.weight(.bold))
+                .foregroundStyle(Color.hopesTextSecondary)
+                .padding(.bottom, 16)
+
+            ForEach(conversations) { conversation in
+                Button {
+                    onSelectConversation(conversation)
+                } label: {
+                    Text(conversation.title)
+                        .font(.footnote.weight(.medium))
+                        .foregroundStyle(
+                            conversation.title == Self.sampleConversations.first?.title
+                                ? Color.hopesTextPrimary
+                                : Color.hopesTextSecondary
+                        )
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .frame(height: 46)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+
+            if conversations.isEmpty {
+                Text("검색 결과가 없어요.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesTextPlaceholder)
+                    .frame(height: 46)
+            }
+        }
+    }
+
+    private func filteredConversations(
+        for period: Conversation.Period
+    ) -> [Conversation] {
+        conversations.filter { conversation in
+            conversation.period == period
+                && (
+                    trimmedQuery.isEmpty
+                        || conversation.title.localizedCaseInsensitiveContains(trimmedQuery)
+                )
+        }
+    }
+
+    private var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static let sampleConversations: [Conversation] = [
+        Conversation(title: "기숙사 하루 일과가 어떻게 돼?", period: .recent),
+        Conversation(title: "전공 선택은 어떻게 하는 게 좋...", period: .recent),
+        Conversation(title: "여기랑 대덕중에 누가 더 좋음", period: .recent),
+        Conversation(title: "입학하려면 뭘 준비해야 해?", period: .older),
+        Conversation(title: "과랑 전공이랑 뭐가 다름", period: .older),
+        Conversation(title: "후배한테 해주고 싶은 조언 있어?", period: .older),
+        Conversation(title: "가장 예쁜 사람 누구?", period: .older),
+    ]
+}
+
+#Preview("지난 대화") {
+    ConversationHistoryView()
+        .frame(width: 402, height: 874)
+}

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -9,6 +9,7 @@ public struct LoginFlowView: View {
         case chatHome
         case chatDetail
         case answerEvidence
+        case conversationHistory
     }
 
     @State private var screen: Screen
@@ -32,11 +33,14 @@ public struct LoginFlowView: View {
         isChatHomeInitiallyOpen: Bool = false,
         isChatDetailInitiallyOpen: Bool = false,
         isAnswerEvidenceInitiallyOpen: Bool = false,
+        isConversationHistoryInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
         onStartChat: @escaping () -> Void = {}
     ) {
-        let initialScreen: Screen = if isAnswerEvidenceInitiallyOpen {
+        let initialScreen: Screen = if isConversationHistoryInitiallyOpen {
+            .conversationHistory
+        } else if isAnswerEvidenceInitiallyOpen {
             .answerEvidence
         } else if isChatDetailInitiallyOpen {
             .chatDetail
@@ -129,6 +133,18 @@ public struct LoginFlowView: View {
                     },
                     onAskMore: {
                         chatReply = "이 근거를 바탕으로 더 자세히 알려줘."
+                        transition(to: .chatDetail)
+                    }
+                )
+                    .transition(.move(edge: .trailing))
+
+            case .conversationHistory:
+                ConversationHistoryView(
+                    onNewConversation: {
+                        chatMessage = ""
+                        transition(to: .chatHome)
+                    },
+                    onSelectConversation: { _ in
                         transition(to: .chatDetail)
                     }
                 )

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -198,3 +198,17 @@ func answerEvidenceViewCanBeConstructed() {
     )
     _ = LoginFlowView(isAnswerEvidenceInitiallyOpen: true)
 }
+
+@Test
+@MainActor
+func conversationHistoryViewCanBeConstructed() {
+    _ = ConversationHistoryView()
+    _ = ConversationHistoryView(
+        conversations: [
+            .init(title: "기숙사 생활", period: .recent),
+        ],
+        onNewConversation: {},
+        onSelectConversation: { _ in }
+    )
+    _ = LoginFlowView(isConversationHistoryInitiallyOpen: true)
+}


### PR DESCRIPTION
## 📌 변경사항
  - 최근/이전 대화 목록 구현
  - 실시간 검색 필터링 구현
  - 새 대화 시작 → 채팅 홈 연결
  - 대화 선택 → 채팅 상세 연결
  - 기록 탭 활성 상태 반영
  - --show-conversation-history 실행 옵션 추가


## 📷 스크린샷



## 🔗 관련 이슈

close #19

## 💬 참고사항
없음

