### PR TITLE
feat: [#23] 마이페이지 구현'

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -13,7 +13,8 @@ struct HopesApp: App {
                 isChatDetailInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-detail"),
                 isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence"),
                 isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history"),
-                isNotificationsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-notifications")
+                isNotificationsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-notifications"),
+                isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -11,6 +11,7 @@ public struct LoginFlowView: View {
         case answerEvidence
         case conversationHistory
         case notifications
+        case myPage
     }
 
     @State private var screen: Screen
@@ -22,6 +23,8 @@ public struct LoginFlowView: View {
     @State private var cohort = ""
     @State private var chatMessage = ""
     @State private var chatReply = ""
+    @State private var profileName = "임서하"
+    @State private var profileIntroduction = ""
 
     private let onLogin: () -> Void
     private let onSignUp: (SignUpFormData) -> Void
@@ -36,11 +39,14 @@ public struct LoginFlowView: View {
         isAnswerEvidenceInitiallyOpen: Bool = false,
         isConversationHistoryInitiallyOpen: Bool = false,
         isNotificationsInitiallyOpen: Bool = false,
+        isMyPageInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
         onStartChat: @escaping () -> Void = {}
     ) {
-        let initialScreen: Screen = if isNotificationsInitiallyOpen {
+        let initialScreen: Screen = if isMyPageInitiallyOpen {
+            .myPage
+        } else if isNotificationsInitiallyOpen {
             .notifications
         } else if isConversationHistoryInitiallyOpen {
             .conversationHistory
@@ -160,6 +166,16 @@ public struct LoginFlowView: View {
                         transition(to: .chatDetail)
                     }
                 }
+                    .transition(.move(edge: .trailing))
+
+            case .myPage:
+                MyPageView(
+                    name: $profileName,
+                    introduction: $profileIntroduction,
+                    onBackToChat: {
+                        transition(to: .chatHome)
+                    }
+                )
                     .transition(.move(edge: .trailing))
             }
         }

--- a/Sources/HopesDesignSystem/Screens/MyPageView.swift
+++ b/Sources/HopesDesignSystem/Screens/MyPageView.swift
@@ -1,0 +1,232 @@
+import SwiftUI
+
+public struct MyPageView: View {
+    public struct Profile: Equatable, Sendable {
+        public var name: String
+        public var introduction: String
+
+        public init(name: String, introduction: String) {
+            self.name = name
+            self.introduction = introduction
+        }
+    }
+
+    @State private var selectedTab: HopesTab = .settings
+    @State private var lastSavedProfile: Profile
+    @State private var hasSaved = false
+    @Binding private var name: String
+    @Binding private var introduction: String
+
+    private let email: String
+    private let major: String
+    private let onBackToChat: () -> Void
+    private let onSave: (Profile) -> Void
+
+    public init(
+        name: Binding<String>,
+        introduction: Binding<String>,
+        email: String = "s26055@gsm.hs.kr",
+        major: String = "인공지능소프트웨어과",
+        onBackToChat: @escaping () -> Void = {},
+        onSave: @escaping (Profile) -> Void = { _ in }
+    ) {
+        _name = name
+        _introduction = introduction
+        _lastSavedProfile = State(
+            initialValue: Profile(
+                name: name.wrappedValue,
+                introduction: introduction.wrappedValue
+            )
+        )
+        self.email = email
+        self.major = major
+        self.onBackToChat = onBackToChat
+        self.onSave = onSave
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+
+            header
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 70)
+
+            Text("마이페이지")
+                .font(.title.weight(.bold))
+                .foregroundStyle(Color.hopesTextPrimary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 138)
+
+            profileCard
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 190)
+
+            HopesButton(
+                hasSaved && !hasUnsavedChanges ? "저장됨" : "저장",
+                size: .regular,
+                width: .fixed(hasSaved && !hasUnsavedChanges ? 104 : 96),
+                isEnabled: canSave,
+                action: saveProfile
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 48)
+            .padding(.top, 538)
+
+            accountCard
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 628)
+
+            HopesTabBar(selection: $selectedTab)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        HStack {
+            HopesLogo()
+
+            Spacer()
+
+            HopesButton(
+                "채팅으로",
+                variant: .secondary,
+                size: .medium,
+                width: .fixed(78),
+                action: onBackToChat
+            )
+        }
+    }
+
+    private var profileCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("프로필")
+                .font(.headline.weight(.bold))
+                .foregroundStyle(Color.hopesTextPrimary)
+
+            HopesLabeledTextField(
+                "이름",
+                text: $name,
+                placeholder: "이름"
+            )
+            .padding(.top, 22)
+
+            Text("자기소개 (AI 응답 개인화에 활용됩니다)")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(Color.hopesTextPrimary)
+                .padding(.top, 14)
+
+            ZStack(alignment: .topLeading) {
+                if introduction.isEmpty {
+                    Text("예: 프론트엔드에 관심 많은 8기 학생이에요.")
+                        .font(.subheadline)
+                        .foregroundStyle(Color.hopesTextSecondary)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 16)
+                        .allowsHitTesting(false)
+                }
+
+                TextEditor(text: $introduction)
+                    .font(.subheadline)
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .scrollContentBackground(.hidden)
+                    .padding(.horizontal, 11)
+                    .padding(.vertical, 8)
+                    .frame(height: 92)
+            }
+            .background(.white)
+            .clipShape(
+                RoundedRectangle(
+                    cornerRadius: HopesMetrics.controlCornerRadius
+                )
+            )
+            .overlay {
+                RoundedRectangle(
+                    cornerRadius: HopesMetrics.controlCornerRadius
+                )
+                .stroke(Color.hopesBorder, lineWidth: 1)
+            }
+            .padding(.top, 16)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 28)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 326, alignment: .top)
+        .background(.white)
+        .clipShape(
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+    }
+
+    private var accountCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("계정 정보 (수정 불가)")
+                .font(.headline.weight(.bold))
+                .foregroundStyle(Color.hopesTextPrimary)
+
+            Text("이메일: \(email)")
+                .padding(.top, 22)
+
+            Text("전공: \(major)")
+                .padding(.top, 10)
+        }
+        .font(.footnote)
+        .foregroundStyle(Color.hopesTextPrimary)
+        .padding(.horizontal, 24)
+        .padding(.vertical, 24)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 128, alignment: .top)
+        .background(.white)
+        .clipShape(
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+    }
+
+    private var currentProfile: Profile {
+        Profile(
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            introduction: introduction.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+
+    private var hasUnsavedChanges: Bool {
+        currentProfile != lastSavedProfile
+    }
+
+    private var canSave: Bool {
+        !currentProfile.name.isEmpty && (!hasSaved || hasUnsavedChanges)
+    }
+
+    private func saveProfile() {
+        guard canSave else {
+            return
+        }
+
+        name = currentProfile.name
+        introduction = currentProfile.introduction
+        lastSavedProfile = currentProfile
+        hasSaved = true
+        onSave(currentProfile)
+    }
+}
+
+#Preview("마이페이지") {
+    @Previewable @State var name = "임서하"
+    @Previewable @State var introduction = ""
+
+    MyPageView(
+        name: $name,
+        introduction: $introduction
+    )
+    .frame(width: 402, height: 874)
+}

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -229,3 +229,19 @@ func notificationsViewCanBeConstructed() {
     )
     _ = LoginFlowView(isNotificationsInitiallyOpen: true)
 }
+
+@Test
+@MainActor
+func myPageViewCanBeConstructed() {
+    _ = MyPageView(
+        name: .constant("임서하"),
+        introduction: .constant("")
+    )
+    _ = MyPageView(
+        name: .constant("임서하"),
+        introduction: .constant("프론트엔드에 관심이 많아요."),
+        onBackToChat: {},
+        onSave: { _ in }
+    )
+    _ = LoginFlowView(isMyPageInitiallyOpen: true)
+}


### PR DESCRIPTION
## 📌 변경사항
  - 이름·자기소개 편집 구현
  - 프로필 저장 및 저장 완료 상태 반영
  - 이메일·전공 읽기 전용 계정 카드 구현
  - 채팅으로 → 채팅 홈 연결
  - 설정 탭 활성 상태 반영
  - --show-my-page 실행 옵션 추가

## 📷 스크린샷
<img width="454" height="975" alt="스크린샷 2026-07-27 오후 6 45 19" src="https://github.com/user-attachments/assets/9ea99b4b-f10c-44a4-a878-b69aa4958ff7" />



## 🔗 관련 이슈

close #23 

## 💬 참고사항
없음

