### PR TITLE
 feat: [#25] 설정 페이지 퍼블리싱

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -14,7 +14,8 @@ struct HopesApp: App {
                 isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence"),
                 isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history"),
                 isNotificationsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-notifications"),
-                isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page")
+                isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page"),
+                isSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-settings")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Components/HopesButton.swift
+++ b/Sources/HopesDesignSystem/Components/HopesButton.swift
@@ -108,7 +108,7 @@ public struct HopesButton: View {
             .font(size.font)
             .lineLimit(1)
             .foregroundStyle(foregroundColor)
-            .padding(.horizontal, size.horizontalPadding)
+            .padding(.horizontal, horizontalPadding)
             .frame(
                 minWidth: width.minimum,
                 maxWidth: width.maximum,
@@ -125,6 +125,13 @@ public struct HopesButton: View {
             .disabled(!isEnabled)
             .opacity(isEnabled ? 1 : 0.45)
             .accessibilityHint(isEnabled ? "" : "사용할 수 없는 버튼")
+    }
+
+    private var horizontalPadding: CGFloat {
+        if case .fixed = width {
+            return 0
+        }
+        return size.horizontalPadding
     }
 
     private var foregroundColor: Color {

--- a/Sources/HopesDesignSystem/Components/HopesToast.swift
+++ b/Sources/HopesDesignSystem/Components/HopesToast.swift
@@ -25,7 +25,7 @@ public struct HopesToast: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.trailing, 20)
         }
-        .frame(minHeight: 58)
+        .frame(height: 58)
         .background(.white)
         .clipShape(
             RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -12,6 +12,7 @@ public struct LoginFlowView: View {
         case conversationHistory
         case notifications
         case myPage
+        case settings
     }
 
     @State private var screen: Screen
@@ -40,11 +41,14 @@ public struct LoginFlowView: View {
         isConversationHistoryInitiallyOpen: Bool = false,
         isNotificationsInitiallyOpen: Bool = false,
         isMyPageInitiallyOpen: Bool = false,
+        isSettingsInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
         onStartChat: @escaping () -> Void = {}
     ) {
-        let initialScreen: Screen = if isMyPageInitiallyOpen {
+        let initialScreen: Screen = if isSettingsInitiallyOpen {
+            .settings
+        } else if isMyPageInitiallyOpen {
             .myPage
         } else if isNotificationsInitiallyOpen {
             .notifications
@@ -174,6 +178,17 @@ public struct LoginFlowView: View {
                     introduction: $profileIntroduction,
                     onBackToChat: {
                         transition(to: .chatHome)
+                    }
+                )
+                    .transition(.move(edge: .trailing))
+
+            case .settings:
+                SettingsView(
+                    onBackToChat: {
+                        transition(to: .chatHome)
+                    },
+                    onLogout: {
+                        transition(to: .login)
                     }
                 )
                     .transition(.move(edge: .trailing))

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+public struct SettingsView: View {
+    @State private var selectedTab: HopesTab = .settings
+
+    private let contactEmail: String
+    private let onBackToChat: () -> Void
+    private let onOpenGeneral: () -> Void
+    private let onOpenPersonalSettings: () -> Void
+    private let onOpenContact: () -> Void
+    private let onLogout: () -> Void
+
+    public init(
+        contactEmail: String = "gsm-chatbot@gsm.hs.kr",
+        onBackToChat: @escaping () -> Void = {},
+        onOpenGeneral: @escaping () -> Void = {},
+        onOpenPersonalSettings: @escaping () -> Void = {},
+        onOpenContact: @escaping () -> Void = {},
+        onLogout: @escaping () -> Void = {}
+    ) {
+        self.contactEmail = contactEmail
+        self.onBackToChat = onBackToChat
+        self.onOpenGeneral = onOpenGeneral
+        self.onOpenPersonalSettings = onOpenPersonalSettings
+        self.onOpenContact = onOpenContact
+        self.onLogout = onLogout
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+
+            header
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 76)
+
+            settingsCard
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 172)
+
+            HopesToast("문의: \(contactEmail)")
+                .padding(.horizontal, 44)
+                .padding(.top, 536)
+
+            HopesTabBar(selection: $selectedTab)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("설정")
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("앱 설정과 도움말을 관리해요.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            }
+
+            Spacer()
+
+            HopesButton(
+                "채팅으로",
+                variant: .secondary,
+                size: .small,
+                width: .fixed(54),
+                action: onBackToChat
+            )
+        }
+    }
+
+    private var settingsCard: some View {
+        HopesCard(padding: 20) {
+            VStack(spacing: 12) {
+                HopesActionRow(
+                    title: "일반",
+                    subtitle: "다크 모드, 표시 방식",
+                    action: onOpenGeneral
+                )
+
+                HopesActionRow(
+                    title: "개인 설정",
+                    subtitle: "시스템 프롬프트 관리",
+                    action: onOpenPersonalSettings
+                )
+
+                HopesActionRow(
+                    title: "문의하기",
+                    subtitle: contactEmail,
+                    action: onOpenContact
+                )
+
+                HopesButton(
+                    "로그아웃",
+                    variant: .danger,
+                    size: .regular,
+                    action: onLogout
+                )
+            }
+        }
+        .frame(height: 317)
+    }
+}
+
+#Preview("설정") {
+    SettingsView()
+        .frame(width: 402, height: 874)
+}

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -120,6 +120,13 @@ func toastVariantsCanBeConstructed() {
 
 @Test
 @MainActor
+func settingsViewCanBeConstructed() {
+    _ = SettingsView()
+    _ = LoginFlowView(isSettingsInitiallyOpen: true)
+}
+
+@Test
+@MainActor
 func loginSwipeGuideCanBeConstructed() {
     _ = LoginSwipeGuideView()
     _ = LoginSwipeGuideView(onOpenLogin: {})


### PR DESCRIPTION
## 📌 변경사항
  - Figma 11 설정 / iPhone 17 Pro 프레임 기준 적용
  - 설정 헤더와 채팅으로 버튼
  - 일반·개인 설정·문의하기 행
  - 로그아웃 버튼
  - 문의 이메일 토스트
  - 설정 활성 상태 하단 탭바
  - --show-settings 실행 옵션 추가
  - 채팅 복귀와 로그아웃 화면 전환 연결
  - 공용 버튼 고정폭 잘림 및 토스트 높이 문제 수정

## 📷 스크린샷
<img width="479" height="1057" alt="스크린샷 2026-08-02 오전 12 44 46" src="https://github.com/user-attachments/assets/bc9b44a6-2ef0-49d8-b295-068e7e48b59f" />



## 🔗 관련 이슈

close #25 

## 💬 참고사항
없음

