### PR TITLE
feat: [#27] 일반설정  페이지 퍼블리싱

### DIFF
--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -15,7 +15,8 @@ struct HopesApp: App {
                 isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history"),
                 isNotificationsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-notifications"),
                 isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page"),
-                isSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-settings")
+                isSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-settings"),
+                isGeneralSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-general-settings")
             )
         }
     }

--- a/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
@@ -1,0 +1,210 @@
+import SwiftUI
+
+public struct GeneralSettingsView: View {
+    @State private var selectedTab: HopesTab = .settings
+    @State private var isDarkModeEnabled: Bool
+    @State private var savedDarkModeEnabled: Bool
+
+    private let onBack: () -> Void
+    private let onDone: () -> Void
+    private let onBackToChat: () -> Void
+    private let onSave: (Bool) -> Void
+
+    public init(
+        isDarkModeEnabled: Bool = false,
+        onBack: @escaping () -> Void = {},
+        onDone: @escaping () -> Void = {},
+        onBackToChat: @escaping () -> Void = {},
+        onSave: @escaping (Bool) -> Void = { _ in }
+    ) {
+        _isDarkModeEnabled = State(initialValue: isDarkModeEnabled)
+        _savedDarkModeEnabled = State(initialValue: isDarkModeEnabled)
+        self.onBack = onBack
+        self.onDone = onDone
+        self.onBackToChat = onBackToChat
+        self.onSave = onSave
+    }
+
+    public var body: some View {
+        ZStack(alignment: .top) {
+            Color.hopesBackground
+
+            header
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 72)
+
+            generalCard
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 158)
+
+            actionButtons
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 688)
+
+            HopesTabBar(selection: $selectedTab)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+        }
+        .ignoresSafeArea()
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .frame(width: 38, height: 38)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 13))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 13)
+                            .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("설정으로 돌아가기")
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("일반 설정")
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("기본 앱 동작을 조정해요.")
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HopesButton(
+                "완료",
+                variant: .secondary,
+                size: .small,
+                width: .fixed(54),
+                action: complete
+            )
+        }
+    }
+
+    private var generalCard: some View {
+        HopesCard(padding: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("일반")
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+                    .padding(.leading, 24)
+                    .padding(.top, 28)
+
+                darkModeRow
+                    .padding(.horizontal, 10)
+                    .padding(.top, 28)
+
+                backToChatRow
+                    .padding(.horizontal, 10)
+                    .padding(.top, 16)
+            }
+        }
+        .frame(height: 270)
+    }
+
+    private var darkModeRow: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("다크 모드")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("시스템 설정에 맞춰 전환")
+                    .font(.caption)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            }
+
+            Spacer()
+
+            Toggle("다크 모드", isOn: $isDarkModeEnabled)
+                .labelsHidden()
+                .tint(.hopesBrandPrimary)
+        }
+        .padding(.horizontal, 20)
+        .frame(height: 78)
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.045), radius: 7, y: 4)
+    }
+
+    private var backToChatRow: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 5) {
+                Text("뒤로")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+
+                Text("채팅 화면으로 돌아가기")
+                    .font(.caption)
+                    .foregroundStyle(Color.hopesTextSecondary)
+            }
+
+            Spacer()
+
+            HopesButton(
+                "이동",
+                variant: .secondary,
+                size: .compact,
+                width: .fixed(56),
+                action: onBackToChat
+            )
+        }
+        .padding(.horizontal, 19)
+        .frame(height: 72)
+        .background(.white)
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .overlay {
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color.hopesBorder, lineWidth: 1)
+        }
+        .shadow(color: Color.black.opacity(0.045), radius: 7, y: 4)
+    }
+
+    private var actionButtons: some View {
+        HStack(spacing: 14) {
+            HopesButton(
+                "저장",
+                size: .regular,
+                width: .fixed(170),
+                action: save
+            )
+
+            HopesButton(
+                "초기화",
+                variant: .secondary,
+                size: .regular,
+                width: .fixed(170),
+                action: reset
+            )
+        }
+    }
+
+    private func save() {
+        savedDarkModeEnabled = isDarkModeEnabled
+        onSave(isDarkModeEnabled)
+    }
+
+    private func reset() {
+        isDarkModeEnabled = false
+    }
+
+    private func complete() {
+        if savedDarkModeEnabled != isDarkModeEnabled {
+            save()
+        }
+        onDone()
+    }
+}
+
+#Preview("일반 설정") {
+    GeneralSettingsView()
+        .frame(width: 402, height: 874)
+}

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -13,6 +13,7 @@ public struct LoginFlowView: View {
         case notifications
         case myPage
         case settings
+        case generalSettings
     }
 
     @State private var screen: Screen
@@ -42,11 +43,14 @@ public struct LoginFlowView: View {
         isNotificationsInitiallyOpen: Bool = false,
         isMyPageInitiallyOpen: Bool = false,
         isSettingsInitiallyOpen: Bool = false,
+        isGeneralSettingsInitiallyOpen: Bool = false,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping (SignUpFormData) -> Void = { _ in },
         onStartChat: @escaping () -> Void = {}
     ) {
-        let initialScreen: Screen = if isSettingsInitiallyOpen {
+        let initialScreen: Screen = if isGeneralSettingsInitiallyOpen {
+            .generalSettings
+        } else if isSettingsInitiallyOpen {
             .settings
         } else if isMyPageInitiallyOpen {
             .myPage
@@ -187,8 +191,25 @@ public struct LoginFlowView: View {
                     onBackToChat: {
                         transition(to: .chatHome)
                     },
+                    onOpenGeneral: {
+                        transition(to: .generalSettings)
+                    },
                     onLogout: {
                         transition(to: .login)
+                    }
+                )
+                    .transition(.move(edge: .trailing))
+
+            case .generalSettings:
+                GeneralSettingsView(
+                    onBack: {
+                        transition(to: .settings)
+                    },
+                    onDone: {
+                        transition(to: .settings)
+                    },
+                    onBackToChat: {
+                        transition(to: .chatHome)
                     }
                 )
                     .transition(.move(edge: .trailing))

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -127,6 +127,14 @@ func settingsViewCanBeConstructed() {
 
 @Test
 @MainActor
+func generalSettingsViewCanBeConstructed() {
+    _ = GeneralSettingsView()
+    _ = GeneralSettingsView(isDarkModeEnabled: true)
+    _ = LoginFlowView(isGeneralSettingsInitiallyOpen: true)
+}
+
+@Test
+@MainActor
 func loginSwipeGuideCanBeConstructed() {
     _ = LoginSwipeGuideView()
     _ = LoginSwipeGuideView(onOpenLogin: {})


### PR DESCRIPTION
## 📌 변경사항
  - 피그마 12 일반 설정 디자인 반영
  - 다크 모드 토글 작동
  - 저장·초기화·완료 버튼 작동
  - 뒤로가기 및 채팅 화면 이동 연결
  - 기존 설정 화면의 일반 → 열기 연결


## 📷 스크린샷
<img width="474" height="1037" alt="스크린샷 2026-08-02 오전 1 57 47" src="https://github.com/user-attachments/assets/9eeab1ef-25f8-4c21-92a9-01d18def8941" />



## 🔗 관련 이슈

close #27 

## 💬 참고사항
없음


