### PR TITLE
feat: [#36] 온보딩 페이지 피그마 디자인 동기화

### DIFF
--- a/Sources/HopesDesignSystem/Screens/OnboardingView.swift
+++ b/Sources/HopesDesignSystem/Screens/OnboardingView.swift
@@ -35,19 +35,23 @@ public struct OnboardingView: View {
                 .padding(.top, 330)
 
             tipCard(
-                "1. “기숙사 어때?”보다 “1학년 기숙사 평일 루틴\n알려줘”"
+                number: "1",
+                caption: "“기숙사 어때” 보단,",
+                detail: "“1학년 기숙사 평일 루틴 알려줘”"
             )
             .padding(.top, 450)
 
             tipCard(
-                "2. 입학/전공/학교생활 중 카테고리를 먼저 골라\n요."
+                number: "2",
+                caption: "질문 전에,",
+                detail: "입학 / 전공 / 학교생활 중 카테고리를 골라요."
             )
-            .padding(.top, 546)
+            .padding(.top, 543)
 
             HopesButton(
                 "채팅 시작하기",
-                variant: .dark,
-                size: .extraLarge,
+                variant: .secondary,
+                size: .regular,
                 width: .fixed(338),
                 action: onStartChat
             )
@@ -59,20 +63,34 @@ public struct OnboardingView: View {
         .ignoresSafeArea()
     }
 
-    private func tipCard(_ text: String) -> some View {
+    private func tipCard(number: String, caption: String, detail: String) -> some View {
         HopesCard(
             padding: 0,
             cornerRadius: HopesMetrics.cardCornerRadius,
             elevation: .flat
         ) {
-            Text(text)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(Color.hopesTextPrimary)
-                .lineSpacing(2)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 22)
-                .padding(.top, 24)
-                .frame(maxHeight: .infinity, alignment: .top)
+            HStack(alignment: .top, spacing: 12) {
+                Text(number)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Color(red: 10 / 255, green: 90 / 255, blue: 150 / 255))
+                    .frame(width: 24, height: 24)
+                    .background(Color.hopesBrandTint)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(caption)
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(Color.hopesTextSecondary)
+
+                    Text(detail)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(Color.hopesTextPrimary)
+                        .lineLimit(2)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 14)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         }
         .frame(width: 338, height: 78)
     }


### PR DESCRIPTION
## 📌 변경사항

- 온보딩 CTA 버튼을 Figma 디자인의 흰색 버튼으로 동기화했습니다.
- 안내 카드에 번호 배지, 보조 문구, 질문 예시 구조를 반영했습니다.
- 두 번째 안내 카드 위치와 문구를 Figma 기준으로 조정했습니다.

## 🔗 관련 이슈

close #36

## 💬 참고사항

- `swift test` 23개 테스트 통과
- iOS Simulator Debug 빌드 성공
- iPhone 17 Pro 시뮬레이터에서 화면 검증 완료