### PR TITLE
feat: [#40] 로그인 안내 페이지 퍼블리싱

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginSwipeGuideView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginSwipeGuideView.swift
@@ -95,26 +95,16 @@ public struct LoginSwipeGuideView: View {
                 .frame(width: 86, height: 5)
                 .padding(.top, 20)
 
-            HStack(alignment: .top, spacing: 16) {
-                VStack(alignment: .leading, spacing: 7) {
-                    Text("로그인")
-                        .font(HopesTypography.inter(size: 25, weight: .bold, relativeTo: .title2))
-                        .foregroundStyle(Color("HopesSheetTitle", bundle: .module))
+            VStack(alignment: .leading, spacing: 7) {
+                Text("로그인")
+                    .font(HopesTypography.inter(size: 25, weight: .bold, relativeTo: .title2))
+                    .foregroundStyle(Color("HopesSheetTitle", bundle: .module))
 
-                    Text("학교 이메일로 로그인하세요.")
-                        .font(HopesTypography.inter(size: 12, relativeTo: .caption))
-                        .foregroundStyle(Color("HopesSheetSecondary", bundle: .module))
-                }
-
-                Spacer(minLength: 0)
-
-                HopesButton(
-                    "열기",
-                    size: .medium,
-                    width: .fixed(66),
-                    action: openLogin
-                )
+                Text("학교 이메일로 로그인하세요.")
+                    .font(HopesTypography.inter(size: 12, relativeTo: .caption))
+                    .foregroundStyle(Color("HopesSheetSecondary", bundle: .module))
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 30)
             .padding(.top, 78)
         }
@@ -128,6 +118,8 @@ public struct LoginSwipeGuideView: View {
             )
         )
         .shadow(color: Color(red: 10 / 255, green: 31 / 255, blue: 56 / 255).opacity(0.16), radius: 14, y: -6)
+        .contentShape(Rectangle())
+        .onTapGesture(perform: openLogin)
         .accessibilityAction(named: "로그인 열기", openLogin)
     }
 


### PR DESCRIPTION
## 📌 변경사항

- 로그인 안내 시트의 제목과 설명 배치를 구성했습니다.
- 디자인에 없는 열기 버튼을 제거했습니다.
- 시트 탭과 위로 스와이프 동작으로 로그인을 열 수 있도록 유지했습니다.

## 🔗 관련 이슈

close #40

## 💬 참고사항

- `swift test` 23개 테스트 통과
- iOS Simulator Debug 빌드 성공
- iPhone 17 Pro 시뮬레이터에서 화면 검증 완료