### PR TITLE
feat: [#44] 마이페이지 퍼블리싱

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -198,7 +198,7 @@ public struct LoginFlowView: View {
                     name: $profileName,
                     introduction: $profileIntroduction,
                     onBackToChat: {
-                        transition(to: .chatHome)
+                        transition(to: .settings)
                     },
                     onOpenAccountInfo: {
                         transition(to: .accountInfo)

--- a/Sources/HopesDesignSystem/Screens/MyPageView.swift
+++ b/Sources/HopesDesignSystem/Screens/MyPageView.swift
@@ -65,9 +65,17 @@ public struct MyPageView: View {
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
                 .padding(.top, 138)
 
+            Button(action: onOpenAccountInfo) {
+                accountCard
+            }
+            .buttonStyle(.plain)
+            .accessibilityHint("계정 정보 상세 화면을 엽니다")
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 194)
+
             profileCard
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 190)
+                .padding(.top, 350)
 
             HopesButton(
                 hasSaved && !hasUnsavedChanges ? "저장됨" : "저장",
@@ -77,16 +85,8 @@ public struct MyPageView: View {
                 action: saveProfile
             )
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 48)
-            .padding(.top, 538)
-
-            Button(action: onOpenAccountInfo) {
-                accountCard
-            }
-            .buttonStyle(.plain)
-            .accessibilityHint("계정 정보 상세 화면을 엽니다")
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 628)
+            .padding(.horizontal, 18)
+            .padding(.top, 694)
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -101,10 +101,10 @@ public struct MyPageView: View {
             Spacer()
 
             HopesButton(
-                "채팅으로",
+                "설정",
                 variant: .secondary,
-                size: .medium,
-                width: .fixed(78),
+                size: .small,
+                width: .fixed(54),
                 action: onBackToChat
             )
         }


### PR DESCRIPTION
## 📌 변경사항

- 계정 정보와 프로필 카드를 디자인 순서로 구성했습니다.
- 프로필 저장 버튼 위치를 정리했습니다.
- 상단 설정 버튼을 설정 페이지로 연결했습니다.

## 🔗 관련 이슈

close #44

## 💬 참고사항

- `swift test` 23개 테스트 통과
- iOS Simulator Debug 빌드 성공
- iPhone 17 Pro 시뮬레이터에서 화면 검증 완료