### PR TITLE
feat: [#50] 채팅 상세 페이지 퍼블리싱

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
@@ -43,11 +43,11 @@ public struct ChatDetailView: View {
 
             responseActions
                 .padding(.leading, 44)
-                .padding(.top, 386)
+                .padding(.top, 364)
 
             sourceCard
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 452)
+                .padding(.top, 430)
 
             composer
                 .padding(.top, 716)
@@ -123,7 +123,7 @@ public struct ChatDetailView: View {
         .lineSpacing(2)
         .padding(.horizontal, 20)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 132)
+        .frame(height: 110)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
         .overlay {


### PR DESCRIPTION
## 📌 변경사항

- 질문과 답변 말풍선 높이를 구성했습니다.
- 답변 액션과 근거 카드 배치를 정리했습니다.
- 하단 추가 질문 입력 영역을 유지했습니다.

## 🔗 관련 이슈

close #50

## 💬 참고사항

- `swift test` 23개 테스트 통과
- iOS Simulator Debug 빌드 성공
- iPhone 17 Pro 시뮬레이터에서 화면 검증 완료