### PR TITLE
feat: [#54] 공통 탭바 퍼블리싱

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -72,7 +72,7 @@ public struct HopesTabBar: View {
             }
         }
         .padding(.leading, 25)
-        .padding(.top, 10)
+        .padding(.top, 12)
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 84, alignment: .top)
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## 📌 변경사항

- 공통 탭바의 선택 캡슐 위치를 구성했습니다.
- 탭 아이콘과 라벨의 수직 간격을 조정했습니다.
- 모든 탭 화면에 동일한 배치가 적용됩니다.

## 🔗 관련 이슈

close #54

## 💬 참고사항

- `swift test` 23개 테스트 통과
- iOS Simulator Debug 빌드 성공
- iPhone 17 Pro 시뮬레이터에서 화면 검증 완료