### PR TITLE
fix: [#56] 로그인·채팅 홈 미세 퍼블리싱 조정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
@@ -51,7 +51,7 @@ public struct ChatHomeView: View {
             }
             .padding(.top, 283)
 
-            VStack(spacing: 14) {
+            VStack(spacing: 6) {
                 ForEach(suggestions, id: \.1) { icon, title in
                     HopesQuestionCard(title: title) {
                         message = title
@@ -83,7 +83,7 @@ public struct ChatHomeView: View {
                 "새 대화",
                 variant: .secondary,
                 size: .medium,
-                width: .fixed(78)
+                width: .fixed(70)
             ) {
                 message = ""
                 onNewChat()
@@ -93,7 +93,7 @@ public struct ChatHomeView: View {
 
     private var composer: some View {
         HStack(spacing: 8) {
-            TextField("선배에게 메시지 보내기...", text: $message)
+            TextField("선배에게 메시지 보내기", text: $message)
                 .font(.footnote)
                 .foregroundStyle(Color.hopesTextPrimary)
                 .onSubmit(sendMessage)
@@ -102,7 +102,7 @@ public struct ChatHomeView: View {
                 Image(systemName: "arrow.up")
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(.white)
-                    .frame(width: 38, height: 38)
+                    .frame(width: 30, height: 30)
                     .background(Color.hopesBrandPrimary)
                     .clipShape(
                         RoundedRectangle(
@@ -113,8 +113,8 @@ public struct ChatHomeView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("메시지 보내기")
         }
-        .padding(.leading, 20)
-        .padding(.trailing, 14)
+        .padding(.leading, 14)
+        .padding(.trailing, 18)
         .frame(height: 52)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -69,41 +69,52 @@ public struct LoginView: View {
                 Text("이메일")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(Color.hopesTextPrimary)
-                    .padding(.top, 42)
+                    .padding(.top, 39)
 
-                TextField("", text: $email)
+                TextField("이메일", text: $email)
                     .hopesEmailInputTraits()
                     .font(.system(size: 15))
                     .foregroundStyle(Color.hopesTextPrimary)
-                    .padding(.horizontal, 13)
+                    .padding(.horizontal, 16)
                     .frame(height: 40)
-                    .background(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255))
+                    .background(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 14))
-                    .padding(.horizontal, 3)
-                    .padding(.top, 12)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255), lineWidth: 1)
+                    }
+                    .padding(.top, 7)
                     .accessibilityLabel("이메일")
 
                 Text("비밀번호")
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(Color.hopesTextPrimary)
-                    .padding(.top, 18)
+                    .padding(.top, 15)
 
-                SecureField("", text: $password)
+                SecureField("비밀번호", text: $password)
                     .hopesPasswordInputTraits()
                     .font(.system(size: 15))
                     .foregroundStyle(Color.hopesTextPrimary)
-                    .padding(.horizontal, 16)
-                    .frame(height: 52)
-                    .overlay(alignment: .top) {
-                        Rectangle()
-                            .fill(Color.hopesBorder)
-                            .frame(height: 1)
+                    .padding(.leading, 16)
+                    .padding(.trailing, 42)
+                    .frame(height: 40)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 14))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 14)
+                            .stroke(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255), lineWidth: 1)
                     }
-                    .padding(.top, 10)
+                    .overlay(alignment: .trailing) {
+                        Image(systemName: "eye.slash")
+                            .font(.system(size: 14))
+                            .foregroundStyle(Color.hopesTextSecondary)
+                            .padding(.trailing, 10)
+                    }
+                    .padding(.top, 9)
                     .accessibilityLabel("비밀번호")
             }
             .padding(.horizontal, 32)
-            .padding(.top, 110)
+            .padding(.top, 68)
 
             HopesButton("로그인", action: onLogin)
                 .padding(.horizontal, 32)
@@ -117,7 +128,7 @@ public struct LoginView: View {
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 32)
-            .padding(.top, 419)
+            .padding(.top, 422)
         }
         .frame(height: 502, alignment: .top)
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## 📌 변경사항

- 로그인 입력 필드 크기, 테두리, 간격을 Figma 수치에 맞게 조정
- 채팅 홈 추천 카드 간격과 새 대화 버튼 너비 조정
- 메시지 입력 문구, 전송 버튼 크기 및 내부 여백 조정

## 🔗 관련 이슈

close #56

## 💬 참고사항

- Test Suite 'All tests' started at 2026-08-12 23:34:33.032.
Test Suite 'All tests' passed at 2026-08-12 23:34:33.033.
	 Executed 0 tests, with 0 failures (0 unexpected) in 0.000 (0.001) seconds
◇ Test run started.
↳ Testing Library Version: 1902
↳ Target Platform: arm64e-apple-macos14.0
◇ Test buttonVariantsCanBeConstructed() started.
◇ Test labeledTextFieldVariantsCanBeConstructed() started.
◇ Test generalSettingsViewCanBeConstructed() started.
◇ Test toastVariantsCanBeConstructed() started.
◇ Test logoMetricsMatchFigma() started.
◇ Test personalSettingsViewCanBeConstructed() started.
◇ Test cardVariantsCanBeConstructed() started.
◇ Test actionRowVariantsCanBeConstructed() started.
◇ Test notificationsViewCanBeConstructed() started.
◇ Test settingsViewCanBeConstructed() started.
◇ Test loginSwipeGuideCanBeConstructed() started.
◇ Test onboardingViewCanBeConstructed() started.
◇ Test conversationHistoryViewCanBeConstructed() started.
◇ Test myPageViewCanBeConstructed() started.
◇ Test loginViewsCanBeConstructed() started.
◇ Test signUpViewCanBeConstructed() started.
◇ Test statTileVariantsCanBeConstructed() started.
◇ Test chatDetailViewCanBeConstructed() started.
◇ Test logoCanBeConstructed() started.
◇ Test chatHomeViewCanBeConstructed() started.
◇ Test contactViewCanBeConstructed() started.
◇ Test questionCardCanBeConstructed() started.
◇ Test answerEvidenceViewCanBeConstructed() started.
✔ Test logoMetricsMatchFigma() passed after 0.001 seconds.
✔ Test labeledTextFieldVariantsCanBeConstructed() passed after 0.001 seconds.
✔ Test actionRowVariantsCanBeConstructed() passed after 0.001 seconds.
✔ Test buttonVariantsCanBeConstructed() passed after 0.001 seconds.
✔ Test toastVariantsCanBeConstructed() passed after 0.002 seconds.
✔ Test settingsViewCanBeConstructed() passed after 0.003 seconds.
✔ Test myPageViewCanBeConstructed() passed after 0.003 seconds.
✔ Test notificationsViewCanBeConstructed() passed after 0.004 seconds.
✔ Test conversationHistoryViewCanBeConstructed() passed after 0.004 seconds.
✔ Test loginViewsCanBeConstructed() passed after 0.004 seconds.
✔ Test onboardingViewCanBeConstructed() passed after 0.004 seconds.
✔ Test statTileVariantsCanBeConstructed() passed after 0.004 seconds.
✔ Test signUpViewCanBeConstructed() passed after 0.004 seconds.
✔ Test chatDetailViewCanBeConstructed() passed after 0.004 seconds.
✔ Test loginSwipeGuideCanBeConstructed() passed after 0.004 seconds.
✔ Test logoCanBeConstructed() passed after 0.004 seconds.
✔ Test personalSettingsViewCanBeConstructed() passed after 0.005 seconds.
✔ Test chatHomeViewCanBeConstructed() passed after 0.005 seconds.
✔ Test contactViewCanBeConstructed() passed after 0.005 seconds.
✔ Test generalSettingsViewCanBeConstructed() passed after 0.005 seconds.
✔ Test cardVariantsCanBeConstructed() passed after 0.005 seconds.
✔ Test answerEvidenceViewCanBeConstructed() passed after 0.005 seconds.
✔ Test questionCardCanBeConstructed() passed after 0.005 seconds.
✔ Test run with 23 tests in 0 suites passed after 0.005 seconds. 23개 통과