### PR TITLE
fix: [#58] 탭바 버튼 정렬 구조 수정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -47,13 +47,8 @@ public struct HopesTabBar: View {
                                     ? Color.hopesBrandPrimary
                                     : Color.hopesTextPlaceholder
                             )
-                            .frame(width: 60, height: 30)
-                            .background(
-                                selection == tab
-                                    ? Color.hopesBrandTint
-                                    : .clear
-                            )
-                            .clipShape(Capsule())
+                            .frame(width: 34, height: 14)
+                            .modifier(TabIconContainerModifier(isSelected: selection == tab))
 
                         Text(tab.title)
                             .font(.system(size: 10, weight: .semibold))
@@ -62,8 +57,9 @@ public struct HopesTabBar: View {
                                     ? Color.hopesBrandPrimary
                                     : Color.hopesTextSecondary
                             )
+                            .frame(width: 46, height: 12, alignment: .center)
                     }
-                    .frame(width: 60)
+                    .frame(width: 60, height: 42, alignment: .top)
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -82,6 +78,19 @@ public struct HopesTabBar: View {
                 .fill(Color.hopesBorder)
                 .frame(height: 1)
         }
+    }
+}
+
+private struct TabIconContainerModifier: ViewModifier {
+    let isSelected: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .frame(width: 60, height: 30, alignment: .center)
+            .background {
+                Capsule()
+                    .fill(isSelected ? Color.hopesBrandTint : .clear)
+            }
     }
 }
 


### PR DESCRIPTION
## 📌 변경사항

- 선택 배경과 아이콘 중앙 정렬을 전용 modifier로 분리
- 모든 탭 버튼에 동일한 고정 프레임 적용
- 선택 상태 변경 시 탭 내부 구조가 밀리지 않도록 수정

## 🔗 관련 이슈

close #58

## 💬 참고사항

- Swift 테스트 23개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공