### PR TITLE
fix: [#60] 탭바 버튼 균등 중앙 배치

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -33,7 +33,7 @@ public struct HopesTabBar: View {
     }
 
     public var body: some View {
-        HStack(alignment: .top, spacing: 28) {
+        HStack(alignment: .top, spacing: 0) {
             ForEach(HopesTab.allCases, id: \.self) { tab in
                 Button {
                     selection = tab
@@ -62,14 +62,14 @@ public struct HopesTabBar: View {
                     .frame(width: 60, height: 42, alignment: .top)
                     .contentShape(Rectangle())
                 }
+                .frame(maxWidth: .infinity, alignment: .center)
                 .buttonStyle(.plain)
                 .accessibilityLabel(tab.title)
                 .accessibilityAddTraits(selection == tab ? .isSelected : [])
             }
         }
-        .padding(.leading, 25)
         .padding(.top, 12)
-        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(maxWidth: .infinity)
         .frame(height: 84, alignment: .top)
         .frame(maxWidth: .infinity)
         .background(.white)

--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -68,6 +68,7 @@ public struct HopesTabBar: View {
                 .accessibilityAddTraits(selection == tab ? .isSelected : [])
             }
         }
+        .padding(.horizontal, 25)
         .padding(.top, 12)
         .frame(maxWidth: .infinity)
         .frame(height: 84, alignment: .top)


### PR DESCRIPTION
## 📌 변경사항

- 고정 leading 및 spacing 제거
- 탭바 가로 영역을 네 버튼이 동일하게 분배하도록 수정
- 각 버튼을 할당 영역 중앙에 고정

## 🔗 관련 이슈

close #60

## 💬 참고사항

- Swift 테스트 23개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공