### PR TITLE
feat: [#62] 전체 페이지 전환 흐름 연결

### DIFF
--- a/Sources/HopesDesignSystem/Screens/AnswerEvidenceView.swift
+++ b/Sources/HopesDesignSystem/Screens/AnswerEvidenceView.swift
@@ -20,6 +20,7 @@ public struct AnswerEvidenceView: View {
     private let onShare: () -> Void
     private let onOpenEvidence: (Evidence) -> Void
     private let onAskMore: () -> Void
+    private let onSelectTab: (HopesTab) -> Void
 
     public init(
         evidenceItems: [Evidence] = [
@@ -30,13 +31,15 @@ public struct AnswerEvidenceView: View {
         onBack: @escaping () -> Void = {},
         onShare: @escaping () -> Void = {},
         onOpenEvidence: @escaping (Evidence) -> Void = { _ in },
-        onAskMore: @escaping () -> Void = {}
+        onAskMore: @escaping () -> Void = {},
+        onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.evidenceItems = evidenceItems
         self.onBack = onBack
         self.onShare = onShare
         self.onOpenEvidence = onOpenEvidence
         self.onAskMore = onAskMore
+        self.onSelectTab = onSelectTab
     }
 
     public var body: some View {
@@ -63,7 +66,7 @@ public struct AnswerEvidenceView: View {
             .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
             .padding(.top, 684)
 
-            HopesTabBar(selection: $selectedTab)
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
         }
         .ignoresSafeArea()

--- a/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
@@ -10,19 +10,22 @@ public struct ChatDetailView: View {
     private let onShowSources: () -> Void
     private let onSend: (String) -> Void
     private let onShare: () -> Void
+    private let onSelectTab: (HopesTab) -> Void
 
     public init(
         reply: Binding<String>,
         onBack: @escaping () -> Void = {},
         onShowSources: @escaping () -> Void = {},
         onSend: @escaping (String) -> Void = { _ in },
-        onShare: @escaping () -> Void = {}
+        onShare: @escaping () -> Void = {},
+        onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         _reply = reply
         self.onBack = onBack
         self.onShowSources = onShowSources
         self.onSend = onSend
         self.onShare = onShare
+        self.onSelectTab = onSelectTab
     }
 
     public var body: some View {
@@ -52,7 +55,7 @@ public struct ChatDetailView: View {
             composer
                 .padding(.top, 716)
 
-            HopesTabBar(selection: $selectedTab)
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
         }
         .ignoresSafeArea()

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -105,7 +105,10 @@ public struct LoginFlowView: View {
                 LoginView(
                     email: $email,
                     password: $password,
-                    onLogin: onLogin,
+                    onLogin: {
+                        onLogin()
+                        transition(to: .chatHome)
+                    },
                     onSignUp: {
                         transition(to: .signUp)
                     }
@@ -153,7 +156,8 @@ public struct LoginFlowView: View {
                     },
                     onShowSources: {
                         transition(to: .answerEvidence)
-                    }
+                    },
+                    onSelectTab: navigateFromTab
                 )
                     .transition(.move(edge: .trailing))
 
@@ -165,7 +169,8 @@ public struct LoginFlowView: View {
                     onAskMore: {
                         chatReply = "이 근거를 바탕으로 더 자세히 알려줘."
                         transition(to: .chatDetail)
-                    }
+                    },
+                    onSelectTab: navigateFromTab
                 )
                     .transition(.move(edge: .trailing))
 
@@ -266,6 +271,9 @@ public struct LoginFlowView: View {
                     onDone: {
                         transition(to: .settings)
                     },
+                    onSend: { _, _ in
+                        transition(to: .settings)
+                    },
                     onSelectTab: navigateFromTab
                 )
                     .transition(.move(edge: .trailing))
@@ -300,7 +308,7 @@ public struct LoginFlowView: View {
         case .history:
             transition(to: .conversationHistory)
         case .settings:
-            transition(to: .settings)
+            transition(to: .myPage)
         }
     }
 }

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -95,15 +95,20 @@ public struct SettingsView: View {
 
     private var darkModeRow: some View {
         HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("다크 모드")
-                    .font(.callout.weight(.semibold))
-                    .foregroundStyle(Color.hopesTextPrimary)
+            Button(action: onOpenGeneral) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("다크 모드")
+                        .font(.callout.weight(.semibold))
+                        .foregroundStyle(Color.hopesTextPrimary)
 
-                Text("시스템 설정에 맞춰 전환")
-                    .font(.caption)
-                    .foregroundStyle(Color.hopesTextSecondary)
+                    Text("시스템 설정에 맞춰 전환")
+                        .font(.caption)
+                        .foregroundStyle(Color.hopesTextSecondary)
+                }
+                .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityHint("일반 설정 화면을 엽니다")
 
             Spacer(minLength: 8)
 


### PR DESCRIPTION
## 📌 변경사항

- 첫 화면 스와이프 로그인 진입 흐름 검증
- 로그인 완료 후 채팅 홈 화면 연결
- 채팅 상세 및 답변 근거 화면 탭바 연결
- 설정 탭을 마이페이지로 연결하고 마이페이지에서 세부 설정 진입
- 일반 설정 및 문의 완료 흐름 연결

## 🔗 관련 이슈

close #62

## 💬 참고사항

- Swift 테스트 23개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공