### PR TITLE
fix: [#66] 로그인 상단 배경 블러 적용

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -42,6 +42,19 @@ public struct LoginView: View {
             }
 
             VStack(spacing: 0) {
+                Rectangle()
+                    .fill(.ultraThinMaterial)
+                    .overlay {
+                        Color.black.opacity(0.1)
+                    }
+                    .frame(height: 397)
+
+                Spacer(minLength: 0)
+            }
+            .ignoresSafeArea()
+            .allowsHitTesting(false)
+
+            VStack(spacing: 0) {
                 Spacer(minLength: 0)
                 loginSheet
             }


### PR DESCRIPTION
## 📌 변경사항

- 로그인 상단 397pt 영역에 배경 블러 적용
- 피그마 기준 검정 10% 딤 오버레이 적용
- 로그인 시트는 선명하게 유지하도록 레이어 순서 조정

## 🔗 관련 이슈

close #66

## 💬 참고사항

- Swift 테스트 22개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공