### PR TITLE
fix: [#68] 로그인 배경 블러 강도 완화

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -44,8 +44,9 @@ public struct LoginView: View {
             VStack(spacing: 0) {
                 Rectangle()
                     .fill(.ultraThinMaterial)
+                    .opacity(0.55)
                     .overlay {
-                        Color.black.opacity(0.1)
+                        Color.black.opacity(0.06)
                     }
                     .frame(height: 397)
 


### PR DESCRIPTION
## 📌 변경사항

- 상단 블러 레이어 불투명도를 55%로 완화
- 검정 딤 오버레이를 10%에서 6%로 완화

## 🔗 관련 이슈

close #68

## 💬 참고사항

- Swift 테스트 22개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공