### PR TITLE
fix: 로그인 화면 피그마 블러 정확 적용

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -21,33 +21,31 @@ public struct LoginView: View {
 
     public var body: some View {
         ZStack {
-            Color.hopesHeroGradient
-                .ignoresSafeArea()
+            ZStack {
+                Color.hopesHeroGradient
+                    .ignoresSafeArea()
 
-            VStack(spacing: 0) {
-                HopesLogo(placement: .onBrand)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 14)
-                    .padding(.horizontal, 32)
+                VStack(spacing: 0) {
+                    HopesLogo(placement: .onBrand)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 14)
+                        .padding(.horizontal, 32)
 
-                Text("선배에게 묻는\n가장 솔직한\n학교 이야기")
-                    .font(.system(size: 31, weight: .bold))
-                    .foregroundStyle(.white)
-                    .lineSpacing(2)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal, 32)
-                    .padding(.top, 168)
+                    Text("선배에게 묻는\n가장 솔직한\n학교 이야기")
+                        .font(.system(size: 31, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineSpacing(2)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.horizontal, 32)
+                        .padding(.top, 168)
 
-                Spacer(minLength: 0)
+                    Spacer(minLength: 0)
+                }
             }
+            .blur(radius: 8)
 
             VStack(spacing: 0) {
-                Rectangle()
-                    .fill(.ultraThinMaterial)
-                    .opacity(0.55)
-                    .overlay {
-                        Color.black.opacity(0.06)
-                    }
+                Color.black.opacity(0.1)
                     .frame(height: 397)
 
                 Spacer(minLength: 0)


### PR DESCRIPTION
## 변경 사항
- Material 기반 블러를 제거했습니다.
- 피그마 기준으로 배경에 8pt 블러를 적용했습니다.
- 상단 397pt 영역에 검정 10% 오버레이를 적용했습니다.
- 투명 영역을 보존해 로고와 문구가 사각형으로 렌더링되지 않도록 수정했습니다.

## 검증
- swift test: 22개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공
- 로그인 화면 실행 확인

Closes #70