### PR TITLE
feat: 실서버 로그인 API 연동

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -16,6 +16,14 @@ let project = Project(
                 with: [
                     "UILaunchScreen": [:],
                     "UIUserInterfaceStyle": "Light",
+                    "NSAppTransportSecurity": [
+                        "NSExceptionDomains": [
+                            "service.gsmsv.site": [
+                                "NSExceptionAllowsInsecureHTTPLoads": true,
+                                "NSIncludesSubdomains": true,
+                            ],
+                        ],
+                    ],
                 ]
             ),
             sources: ["Sources/**"],

--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public struct LoginRequest: Encodable, Sendable {
+    public let username: String
+    public let password: String
+
+    public init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+}
+
+public struct TokenResponse: Decodable, Sendable, Equatable {
+    public let accessToken: String
+    public let tokenType: String
+}
+
+struct ServerMessage: Decodable {
+    let message: String
+}
+
+public enum HopesAPIError: LocalizedError, Sendable, Equatable {
+    case invalidResponse
+    case unauthorized(String)
+    case server(statusCode: Int, message: String)
+    case transport(String)
+    case decoding
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResponse:
+            "서버 응답을 확인할 수 없습니다."
+        case let .unauthorized(message), let .server(_, message):
+            message
+        case .transport:
+            "서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
+        case .decoding:
+            "서버 응답을 처리하지 못했습니다."
+        }
+    }
+}

--- a/Sources/HopesDesignSystem/Networking/AccessTokenStore.swift
+++ b/Sources/HopesDesignSystem/Networking/AccessTokenStore.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Security
+
+public actor AccessTokenStore {
+    private let service: String
+    private let account = "access-token"
+
+    public init(service: String = "kr.hs.gsm.hopes") {
+        self.service = service
+    }
+
+    public func save(_ token: String) throws {
+        let tokenData = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+
+        SecItemDelete(query as CFDictionary)
+        var attributes = query
+        attributes[kSecValueData as String] = tokenData
+
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        guard status == errSecSuccess else {
+            throw HopesAPIError.transport("Keychain status: \(status)")
+        }
+    }
+
+    public func token() throws -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne,
+        ]
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound { return nil }
+        guard status == errSecSuccess,
+              let data = result as? Data,
+              let token = String(data: data, encoding: .utf8)
+        else {
+            throw HopesAPIError.transport("Keychain status: \(status)")
+        }
+        return token
+    }
+
+    public func clear() throws {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw HopesAPIError.transport("Keychain status: \(status)")
+        }
+    }
+}

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -1,0 +1,86 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+public actor HopesAPIClient {
+    public static let productionBaseURL = URL(string: "http://service.gsmsv.site:22116")!
+    public static let shared = HopesAPIClient()
+
+    private let baseURL: URL
+    private let session: URLSession
+    private let tokenStore: AccessTokenStore
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    public init(
+        baseURL: URL = HopesAPIClient.productionBaseURL,
+        session: URLSession = .shared,
+        tokenStore: AccessTokenStore = AccessTokenStore()
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.tokenStore = tokenStore
+    }
+
+    @discardableResult
+    public func login(username: String, password: String) async throws -> TokenResponse {
+        let response: TokenResponse = try await request(
+            path: "/api/login",
+            method: "POST",
+            body: LoginRequest(username: username, password: password),
+            requiresAuthentication: false
+        )
+        try await tokenStore.save(response.accessToken)
+        return response
+    }
+
+    private func request<Response: Decodable, Body: Encodable>(
+        path: String,
+        method: String,
+        body: Body,
+        requiresAuthentication: Bool
+    ) async throws -> Response {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw HopesAPIError.invalidResponse
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = method
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.timeoutInterval = 20
+        request.httpBody = try encoder.encode(body)
+
+        if requiresAuthentication, let token = try await tokenStore.token() {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw HopesAPIError.transport(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw HopesAPIError.invalidResponse
+        }
+
+        guard 200..<300 ~= httpResponse.statusCode else {
+            let message = (try? decoder.decode(ServerMessage.self, from: data).message)
+                ?? "요청을 처리하지 못했습니다."
+            if httpResponse.statusCode == 401 {
+                throw HopesAPIError.unauthorized(message)
+            }
+            throw HopesAPIError.server(statusCode: httpResponse.statusCode, message: message)
+        }
+
+        do {
+            return try decoder.decode(Response.self, from: data)
+        } catch {
+            throw HopesAPIError.decoding
+        }
+    }
+}

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -21,6 +21,8 @@ public struct LoginFlowView: View {
     @State private var screen: Screen
     @State private var email = ""
     @State private var password = ""
+    @State private var isLoggingIn = false
+    @State private var loginErrorMessage: String?
     @State private var signUpEmail = ""
     @State private var name = ""
     @State private var major = ""
@@ -101,9 +103,10 @@ public struct LoginFlowView: View {
                 LoginView(
                     email: $email,
                     password: $password,
+                    isLoading: isLoggingIn,
+                    errorMessage: loginErrorMessage,
                     onLogin: {
-                        onLogin()
-                        transition(to: .chatHome)
+                        login()
                     },
                     onSignUp: {
                         transition(to: .signUp)
@@ -281,6 +284,33 @@ public struct LoginFlowView: View {
     private func transition(to screen: Screen) {
         withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
             self.screen = screen
+        }
+    }
+
+    private func login() {
+        guard !isLoggingIn else { return }
+        isLoggingIn = true
+        loginErrorMessage = nil
+
+        Task {
+            do {
+                try await HopesAPIClient.shared.login(
+                    username: email.trimmingCharacters(in: .whitespacesAndNewlines),
+                    password: password
+                )
+                await MainActor.run {
+                    isLoggingIn = false
+                    password = ""
+                    onLogin()
+                    transition(to: .chatHome)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoggingIn = false
+                    loginErrorMessage = (error as? LocalizedError)?.errorDescription
+                        ?? "로그인에 실패했습니다."
+                }
+            }
         }
     }
 

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -6,15 +6,21 @@ public struct LoginView: View {
 
     private let onLogin: () -> Void
     private let onSignUp: () -> Void
+    private let isLoading: Bool
+    private let errorMessage: String?
 
     public init(
         email: Binding<String>,
         password: Binding<String>,
+        isLoading: Bool = false,
+        errorMessage: String? = nil,
         onLogin: @escaping () -> Void = {},
         onSignUp: @escaping () -> Void = {}
     ) {
         _email = email
         _password = password
+        self.isLoading = isLoading
+        self.errorMessage = errorMessage
         self.onLogin = onLogin
         self.onSignUp = onSignUp
     }
@@ -128,9 +134,22 @@ public struct LoginView: View {
             .padding(.horizontal, 32)
             .padding(.top, 68)
 
-            HopesButton("로그인", action: onLogin)
+            HopesButton(
+                isLoading ? "로그인 중..." : "로그인",
+                isEnabled: !isLoading && !email.isEmpty && !password.isEmpty,
+                action: onLogin
+            )
                 .padding(.horizontal, 32)
                 .padding(.top, 355)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.hopesDanger)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 32)
+                    .padding(.top, 407)
+            }
 
             Button(action: onSignUp) {
                 Text("계정이 없으신가요?  회원가입")
@@ -140,7 +159,7 @@ public struct LoginView: View {
             }
             .buttonStyle(.plain)
             .padding(.horizontal, 32)
-            .padding(.top, 422)
+            .padding(.top, errorMessage == nil ? 422 : 450)
         }
         .frame(height: 502, alignment: .top)
         .frame(maxWidth: .infinity)

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -3,6 +3,21 @@ import Testing
 @testable import HopesDesignSystem
 
 @Test
+func tokenResponseMatchesServerPayload() throws {
+    let payload = Data(#"{"accessToken":"server-token","tokenType":"Bearer"}"#.utf8)
+    let response = try JSONDecoder().decode(TokenResponse.self, from: payload)
+
+    #expect(response == TokenResponse(accessToken: "server-token", tokenType: "Bearer"))
+}
+
+@Test
+func serverErrorsExposeUserFacingMessages() {
+    let error = HopesAPIError.unauthorized("등록된 회원을 찾을 수 없습니다.")
+
+    #expect(error.errorDescription == "등록된 회원을 찾을 수 없습니다.")
+}
+
+@Test
 func logoMetricsMatchFigma() {
     #expect(HopesMetrics.smallCornerRadius == 12)
 }


### PR DESCRIPTION
## 변경 사항
- 실제 홉스 운영 서버 `service.gsmsv.site:22116` API 클라이언트를 추가했습니다.
- `/api/login`을 실제 호출하고 성공 토큰을 Keychain에 저장합니다.
- 로그인 진행 상태와 서버 오류 메시지를 화면에 연결했습니다.
- HTTP 서버 접근은 해당 서비스 도메인에만 ATS 예외를 적용했습니다.
- 토큰 응답과 서버 오류 처리 테스트를 추가했습니다.

## 실서버 검증
- `GET /api/main`: 인증 전 401 응답 확인
- `POST /api/login`: 실제 DB 미등록 계정 오류 응답 확인

## 테스트
- swift test: 24개 통과
- iPhone 17 Pro 시뮬레이터 빌드 및 실행 성공

Closes #72