### PR TITLE
feat: 실서버 회원가입 및 이메일 인증 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+public enum PasswordPolicy {
+    public static let pattern = #"^(?=.*[A-Za-z])(?=.*\d).{8,15}$"#
+
+    public static func isValid(_ password: String) -> Bool {
+        password.range(of: pattern, options: .regularExpression) != nil
+    }
+}
+
 public struct LoginRequest: Encodable, Sendable {
     public let username: String
     public let password: String
@@ -13,10 +21,35 @@ public struct LoginRequest: Encodable, Sendable {
 public struct TokenResponse: Decodable, Sendable, Equatable {
     public let accessToken: String
     public let tokenType: String
+
+    public init(accessToken: String, tokenType: String) {
+        self.accessToken = accessToken
+        self.tokenType = tokenType
+    }
 }
 
-struct ServerMessage: Decodable {
-    let message: String
+public struct MessageEnvelope: Decodable, Sendable, Equatable {
+    public let message: String
+}
+
+public struct EmailVerificationRequest: Encodable, Sendable {
+    public let email: String
+}
+
+public struct EmailVerificationConfirmRequest: Encodable, Sendable {
+    public let email: String
+    public let code: String
+}
+
+public struct SignupRequest: Encodable, Sendable {
+    public let email: String
+    public let username: String
+    public let password: String
+    public let passwordConfirm: String
+    public let verificationCode: String
+    public let gender: String?
+    public let major: String?
+    public let cohort: Int?
 }
 
 public enum HopesAPIError: LocalizedError, Sendable, Equatable {

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -4,7 +4,16 @@ import FoundationNetworking
 #endif
 
 public actor HopesAPIClient {
-    public static let productionBaseURL = URL(string: "http://service.gsmsv.site:22116")!
+    public static let productionBaseURL: URL = {
+        var components = URLComponents()
+        components.scheme = "http"
+        components.host = "service.gsmsv.site"
+        components.port = 22116
+        guard let url = components.url else {
+            preconditionFailure("Invalid production API URL components")
+        }
+        return url
+    }()
     public static let shared = HopesAPIClient()
 
     private let baseURL: URL
@@ -29,6 +38,38 @@ public actor HopesAPIClient {
             path: "/api/login",
             method: "POST",
             body: LoginRequest(username: username, password: password),
+            requiresAuthentication: false
+        )
+        try await tokenStore.save(response.accessToken)
+        return response
+    }
+
+    @discardableResult
+    public func requestEmailVerification(email: String) async throws -> MessageEnvelope {
+        try await request(
+            path: "/api/signup/email-verifications",
+            method: "POST",
+            body: EmailVerificationRequest(email: email),
+            requiresAuthentication: false
+        )
+    }
+
+    @discardableResult
+    public func confirmEmailVerification(email: String, code: String) async throws -> MessageEnvelope {
+        try await request(
+            path: "/api/signup/email-verifications/confirm",
+            method: "POST",
+            body: EmailVerificationConfirmRequest(email: email, code: code),
+            requiresAuthentication: false
+        )
+    }
+
+    @discardableResult
+    public func signUp(_ signupRequest: SignupRequest) async throws -> TokenResponse {
+        let response: TokenResponse = try await request(
+            path: "/api/signup",
+            method: "POST",
+            body: signupRequest,
             requiresAuthentication: false
         )
         try await tokenStore.save(response.accessToken)
@@ -69,7 +110,7 @@ public actor HopesAPIClient {
         }
 
         guard 200..<300 ~= httpResponse.statusCode else {
-            let message = (try? decoder.decode(ServerMessage.self, from: data).message)
+            let message = (try? decoder.decode(MessageEnvelope.self, from: data).message)
                 ?? "요청을 처리하지 못했습니다."
             if httpResponse.statusCode == 401 {
                 throw HopesAPIError.unauthorized(message)

--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -5,22 +5,40 @@ public struct SignUpFormData: Equatable, Sendable {
     public var name: String
     public var major: String
     public var cohort: String
+    public var password: String
+    public var passwordConfirm: String
+    public var verificationCode: String
 
     public init(
         email: String,
         name: String,
         major: String,
-        cohort: String
+        cohort: String,
+        password: String = "",
+        passwordConfirm: String = "",
+        verificationCode: String = ""
     ) {
         self.email = email
         self.name = name
         self.major = major
         self.cohort = cohort
+        self.password = password
+        self.passwordConfirm = passwordConfirm
+        self.verificationCode = verificationCode
     }
 }
 
 public struct SignUpView: View {
     @State private var selectedTab: HopesTab = .home
+    @State private var verificationCode = ""
+    @State private var password = ""
+    @State private var passwordConfirm = ""
+    @State private var isRequestingVerification = false
+    @State private var isConfirmingVerification = false
+    @State private var isSigningUp = false
+    @State private var isEmailVerified = false
+    @State private var statusMessage: String?
+    @State private var errorMessage: String?
 
     @Binding private var email: String
     @Binding private var name: String
@@ -48,33 +66,37 @@ public struct SignUpView: View {
 
     public var body: some View {
         ZStack(alignment: .top) {
-            Color.hopesBackground
-                .ignoresSafeArea()
-
+            Color.hopesBackground.ignoresSafeArea()
             header
-            formCard
+
+            ScrollView(showsIndicators: false) {
+                VStack(spacing: 20) {
+                    formCard
+                    signUpButton
+                    loginLink
+                }
                 .padding(.top, 217)
+                .padding(.bottom, 112)
+            }
 
-            signUpButton
-                .padding(.top, 645)
-
-            loginLink
-                .padding(.top, 701)
-
-            authTabBar
+            HopesTabBar(selection: $selectedTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
                 .ignoresSafeArea(edges: .bottom)
+        }
+        .onChange(of: email) {
+            isEmailVerified = false
+            verificationCode = ""
+            statusMessage = nil
+            errorMessage = nil
         }
     }
 
     private var header: some View {
         ZStack(alignment: .topLeading) {
             Color.hopesHeroGradient
-
             HopesLogo(placement: .onBrand)
                 .padding(.leading, 32)
                 .padding(.top, 76)
-
             Text("학교 이메일로\n간단히 시작하기")
                 .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(.white)
@@ -88,33 +110,17 @@ public struct SignUpView: View {
 
     private var formCard: some View {
         VStack(spacing: 0) {
-            signUpField(
-                "학교 이메일",
-                text: $email,
-                placeholder: "s26055@gsm.hs.kr",
-                kind: .email
-            )
-            signUpField(
-                "이름",
-                text: $name,
-                placeholder: "임서하"
-            )
-            signUpField(
-                "과",
-                text: $major,
-                placeholder: "AI",
-                kind: .major
-            )
-            signUpField(
-                "기수",
-                text: $cohort,
-                placeholder: "10기",
-                kind: .cohort
-            )
+            signUpField("학교 이메일", text: $email, placeholder: "s26055@gsm.hs.kr", kind: .email)
+            verificationField
+            signUpField("이름", text: $name, placeholder: "임서하")
+            signUpField("비밀번호", text: $password, placeholder: "영문·숫자 포함 8~15자", kind: .password)
+            signUpField("비밀번호 확인", text: $passwordConfirm, placeholder: "비밀번호 재입력", kind: .password)
+            signUpField("과", text: $major, placeholder: "AI", kind: .major)
+            signUpField("기수", text: $cohort, placeholder: "10기", kind: .cohort)
         }
         .padding(.horizontal, 17)
-        .padding(.top, 30)
-        .frame(width: 354, height: 386, alignment: .top)
+        .padding(.vertical, 30)
+        .frame(width: 354)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
         .overlay {
@@ -124,47 +130,35 @@ public struct SignUpView: View {
         .shadow(color: Color(red: 13 / 255, green: 26 / 255, blue: 46 / 255).opacity(0.09), radius: 11, y: 8)
     }
 
-    private var signUpButton: some View {
-        Button {
-            guard isFormValid else {
-                return
+    private var verificationField: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            Text("인증번호")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(Color.hopesTextPrimary)
+
+            HStack(spacing: 8) {
+                TextField("숫자 6자리", text: $verificationCode)
+                    .signUpInputTraits(.verificationCode)
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 15))
+                    .padding(.horizontal, 12)
+                    .frame(height: 43)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)
+                            .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+                    .disabled(isEmailVerified)
+
+                Button(verificationButtonTitle, action: handleVerificationButton)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white)
+                    .frame(width: 86, height: 43)
+                    .background(Color.hopesBrandPrimary)
+                    .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+                    .disabled(isEmailVerified || isRequestingVerification || isConfirmingVerification)
             }
-
-            onSignUp(
-                SignUpFormData(
-                    email: email.trimmingCharacters(in: .whitespacesAndNewlines),
-                    name: name.trimmingCharacters(in: .whitespacesAndNewlines),
-                    major: major.trimmingCharacters(in: .whitespacesAndNewlines),
-                    cohort: cohort.trimmingCharacters(in: .whitespacesAndNewlines)
-                )
-            )
-        } label: {
-            Text("회원가입")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(.white)
-                .frame(width: 354, height: 46)
-                .background(Color.hopesBrandPrimary)
-                .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
         }
-        .buttonStyle(.plain)
-        .accessibilityHint(isFormValid ? "" : "모든 항목을 올바르게 입력해 주세요.")
-    }
-
-    private var loginLink: some View {
-        Button(action: onGoToLogin) {
-            (Text("계정이 있으신가요?  ")
-                .foregroundStyle(Color.hopesTextSecondary)
-                + Text("로그인")
-                .foregroundStyle(Color.hopesBrandPrimary)
-                .underline())
-                .font(.footnote)
-                .frame(width: 338, height: 18)
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var authTabBar: some View {
-        HopesTabBar(selection: $selectedTab)
+        .frame(height: 89, alignment: .top)
     }
 
     private func signUpField(
@@ -182,30 +176,23 @@ public struct SignUpView: View {
                 if kind == .major {
                     Menu {
                         ForEach(["AI", "SW", "IoT"], id: \.self) { option in
-                            Button(option) {
-                                text.wrappedValue = option
-                            }
+                            Button(option) { text.wrappedValue = option }
                         }
                     } label: {
                         HStack {
                             Text(text.wrappedValue.isEmpty ? placeholder : text.wrappedValue)
                                 .foregroundStyle(Color.hopesTextSecondary)
-
                             Spacer()
-
                             Image(systemName: "chevron.down")
                                 .font(.caption2.weight(.semibold))
                                 .foregroundStyle(Color.hopesTextPrimary)
                         }
                     }
+                } else if kind == .password {
+                    SecureField(placeholder, text: text)
                 } else {
-                    TextField(
-                        "",
-                        text: text,
-                        prompt: Text(placeholder)
-                            .foregroundStyle(Color.hopesTextSecondary)
-                    )
-                    .signUpInputTraits(kind)
+                    TextField("", text: text, prompt: Text(placeholder).foregroundStyle(Color.hopesTextSecondary))
+                        .signUpInputTraits(kind)
                 }
             }
             .textFieldStyle(.plain)
@@ -217,23 +204,169 @@ public struct SignUpView: View {
             .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)
-                    .stroke(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255), lineWidth: 1)
+                    .stroke(Color.hopesBorder, lineWidth: 1)
             }
         }
         .frame(height: 89, alignment: .top)
     }
 
-    private var isFormValid: Bool {
-        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasSchoolDomain = trimmedEmail.range(
+    private var signUpButton: some View {
+        Button(action: signUp) {
+            Text(isSigningUp ? "가입 중..." : "회원가입")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(.white)
+                .frame(width: 354, height: 46)
+                .background(Color.hopesBrandPrimary)
+                .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+        }
+        .buttonStyle(.plain)
+        .disabled(!isFormValid || isSigningUp)
+        .opacity(isFormValid && !isSigningUp ? 1 : 0.45)
+        .overlay(alignment: .bottom) {
+            if let message = errorMessage ?? statusMessage {
+                Text(message)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(errorMessage == nil ? Color.hopesSuccess : Color.hopesDanger)
+                    .offset(y: 18)
+            }
+        }
+    }
+
+    private var loginLink: some View {
+        Button(action: onGoToLogin) {
+            (Text("계정이 있으신가요?  ").foregroundStyle(Color.hopesTextSecondary)
+                + Text("로그인").foregroundStyle(Color.hopesBrandPrimary).underline())
+                .font(.footnote)
+                .frame(width: 338, height: 18)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var normalizedEmail: String {
+        email.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSchoolEmailValid: Bool {
+        normalizedEmail.range(
             of: #"^[A-Z0-9._%+-]+@gsm\.hs\.kr$"#,
             options: [.regularExpression, .caseInsensitive]
         ) != nil
+    }
 
-        return hasSchoolDomain
+    private var isVerificationCodeValid: Bool {
+        verificationCode.range(of: #"^\d{6}$"#, options: .regularExpression) != nil
+    }
+
+    private var isFormValid: Bool {
+        isSchoolEmailValid
+            && isEmailVerified
             && !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            && !major.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && !major.isEmpty
             && cohort.rangeOfCharacter(from: .decimalDigits) != nil
+            && PasswordPolicy.isValid(password)
+            && password == passwordConfirm
+    }
+
+    private var verificationButtonTitle: String {
+        if isEmailVerified { return "인증 완료" }
+        if isRequestingVerification { return "발송 중" }
+        if isConfirmingVerification { return "확인 중" }
+        return isVerificationCodeValid ? "인증 확인" : "번호 발송"
+    }
+
+    private func handleVerificationButton() {
+        if isVerificationCodeValid {
+            confirmVerification()
+        } else {
+            requestVerification()
+        }
+    }
+
+    private func requestVerification() {
+        guard isSchoolEmailValid else {
+            errorMessage = "학교 이메일을 올바르게 입력해주세요."
+            return
+        }
+        isRequestingVerification = true
+        errorMessage = nil
+        statusMessage = nil
+        Task {
+            do {
+                let response = try await HopesAPIClient.shared.requestEmailVerification(email: normalizedEmail)
+                await MainActor.run {
+                    isRequestingVerification = false
+                    statusMessage = response.message
+                }
+            } catch {
+                await MainActor.run {
+                    isRequestingVerification = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func confirmVerification() {
+        isConfirmingVerification = true
+        errorMessage = nil
+        Task {
+            do {
+                let response = try await HopesAPIClient.shared.confirmEmailVerification(
+                    email: normalizedEmail,
+                    code: verificationCode
+                )
+                await MainActor.run {
+                    isConfirmingVerification = false
+                    isEmailVerified = true
+                    statusMessage = response.message
+                }
+            } catch {
+                await MainActor.run {
+                    isConfirmingVerification = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func signUp() {
+        guard isFormValid, !isSigningUp else { return }
+        isSigningUp = true
+        errorMessage = nil
+        let formData = SignUpFormData(
+            email: normalizedEmail,
+            name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+            major: major,
+            cohort: cohort,
+            password: password,
+            passwordConfirm: passwordConfirm,
+            verificationCode: verificationCode
+        )
+        Task {
+            do {
+                try await HopesAPIClient.shared.signUp(
+                    SignupRequest(
+                        email: formData.email,
+                        username: formData.name,
+                        password: formData.password,
+                        passwordConfirm: formData.passwordConfirm,
+                        verificationCode: formData.verificationCode,
+                        gender: nil,
+                        major: formData.major,
+                        cohort: Int(formData.cohort.filter(\.isNumber))
+                    )
+                )
+                await MainActor.run {
+                    isSigningUp = false
+                    onSignUp(formData)
+                }
+            } catch {
+                await MainActor.run {
+                    isSigningUp = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
     }
 }
 
@@ -242,6 +375,8 @@ private enum SignUpFieldKind {
     case email
     case major
     case cohort
+    case password
+    case verificationCode
 }
 
 private extension View {
@@ -249,7 +384,7 @@ private extension View {
     func signUpInputTraits(_ kind: SignUpFieldKind) -> some View {
         #if os(iOS)
         switch kind {
-        case .plain, .major:
+        case .plain, .major, .password:
             textInputAutocapitalization(.never)
         case .email:
             textInputAutocapitalization(.never)
@@ -257,6 +392,9 @@ private extension View {
                 .textContentType(.emailAddress)
         case .cohort:
             keyboardType(.numbersAndPunctuation)
+        case .verificationCode:
+            keyboardType(.numberPad)
+                .textContentType(.oneTimeCode)
         }
         #else
         self
@@ -270,11 +408,6 @@ private extension View {
     @Previewable @State var major = ""
     @Previewable @State var cohort = ""
 
-    SignUpView(
-        email: $email,
-        name: $name,
-        major: $major,
-        cohort: $cohort
-    )
-    .frame(width: 402, height: 874)
+    SignUpView(email: $email, name: $name, major: $major, cohort: $cohort)
+        .frame(width: 402, height: 874)
 }

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -18,6 +18,15 @@ func serverErrorsExposeUserFacingMessages() {
 }
 
 @Test
+func passwordPolicyMatchesServerRegex() {
+    #expect(PasswordPolicy.isValid("hopes123"))
+    #expect(!PasswordPolicy.isValid("password"))
+    #expect(!PasswordPolicy.isValid("12345678"))
+    #expect(!PasswordPolicy.isValid("a1short"))
+    #expect(!PasswordPolicy.isValid("hopes12345678901"))
+}
+
+@Test
 func logoMetricsMatchFigma() {
     #expect(HopesMetrics.smallCornerRadius == 12)
 }


### PR DESCRIPTION
## 변경 사항
- 실제 서버 이메일 인증번호 발송 API를 연결했습니다.
- 수신한 6자리 코드의 서버 확인 API를 연결했습니다.
- 인증 완료 후 실제 회원가입 API를 호출하고 발급 토큰을 저장합니다.
- 서버 필수 항목인 비밀번호와 비밀번호 확인 입력을 추가했습니다.
- 비밀번호는 서버와 동일한 regex로 검증합니다.
- base URL 생성의 강제 언래핑을 제거했습니다.
- 이메일 변경 시 기존 인증 상태를 무효화합니다.

## 실서버 검증
- 학교 이메일이 아닌 주소에 대한 400 응답 및 메시지 확인
- 유효 학교 이메일 입력 시 실제 발송 API 호출 구조 확인

## 테스트
- swift test: 25개 통과
- iPhone 17 Pro 시뮬레이터 빌드 및 실행 성공

Closes #74