### PR TITLE
feat: 실서버 메인 및 대화 목록 조회 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -52,6 +52,21 @@ public struct SignupRequest: Encodable, Sendable {
     public let cohort: Int?
 }
 
+public struct ChatSummary: Decodable, Sendable, Equatable, Identifiable {
+    public let id: Int64
+    public let title: String
+    public let updatedAt: String
+}
+
+public struct MainResponse: Decodable, Sendable, Equatable {
+    public let chatList: [ChatSummary]
+    public let newChat: Bool
+    public let searchKeyword: String?
+    public let page: Int
+    public let size: Int
+    public let hasNext: Bool
+}
+
 public enum HopesAPIError: LocalizedError, Sendable, Equatable {
     case invalidResponse
     case unauthorized(String)

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -76,6 +76,31 @@ public actor HopesAPIClient {
         return response
     }
 
+    public func main(
+        searchKeyword: String? = nil,
+        page: Int = 0,
+        size: Int = 50
+    ) async throws -> MainResponse {
+        guard var components = URLComponents(
+            url: baseURL.appending(path: "/api/main"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw HopesAPIError.invalidResponse
+        }
+        var queryItems = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "size", value: String(size)),
+        ]
+        if let searchKeyword, !searchKeyword.isEmpty {
+            queryItems.append(URLQueryItem(name: "searchKeyword", value: searchKeyword))
+        }
+        components.queryItems = queryItems
+        guard let url = components.url else {
+            throw HopesAPIError.invalidResponse
+        }
+        return try await request(url: url, method: "GET", body: nil, requiresAuthentication: true)
+    }
+
     private func request<Response: Decodable, Body: Encodable>(
         path: String,
         method: String,
@@ -86,14 +111,31 @@ public actor HopesAPIClient {
             throw HopesAPIError.invalidResponse
         }
 
+        return try await request(
+            url: url,
+            method: method,
+            body: try encoder.encode(body),
+            requiresAuthentication: requiresAuthentication
+        )
+    }
+
+    private func request<Response: Decodable>(
+        url: URL,
+        method: String,
+        body: Data?,
+        requiresAuthentication: Bool
+    ) async throws -> Response {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.timeoutInterval = 20
-        request.httpBody = try encoder.encode(body)
+        request.httpBody = body
 
-        if requiresAuthentication, let token = try await tokenStore.token() {
+        if requiresAuthentication {
+            guard let token = try await tokenStore.token() else {
+                throw HopesAPIError.unauthorized("로그인이 필요합니다")
+            }
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
 

--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -7,12 +7,12 @@ public struct ConversationHistoryView: View {
             case older
         }
 
-        public let id: String
+        public let id: Int64
         public let title: String
         public let period: Period
 
-        public init(title: String, period: Period) {
-            id = title
+        public init(id: Int64 = 0, title: String, period: Period) {
+            self.id = id
             self.title = title
             self.period = period
         }
@@ -23,19 +23,28 @@ public struct ConversationHistoryView: View {
     @FocusState private var isSearchFocused: Bool
 
     private let conversations: [Conversation]
+    private let isLoading: Bool
+    private let errorMessage: String?
     private let onNewConversation: () -> Void
     private let onSelectConversation: (Conversation) -> Void
+    private let onSearch: (String?) -> Void
     private let onSelectTab: (HopesTab) -> Void
 
     public init(
-        conversations: [Conversation] = Self.sampleConversations,
+        conversations: [Conversation] = [],
+        isLoading: Bool = false,
+        errorMessage: String? = nil,
         onNewConversation: @escaping () -> Void = {},
         onSelectConversation: @escaping (Conversation) -> Void = { _ in },
+        onSearch: @escaping (String?) -> Void = { _ in },
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.conversations = conversations
+        self.isLoading = isLoading
+        self.errorMessage = errorMessage
         self.onNewConversation = onNewConversation
         self.onSelectConversation = onSelectConversation
+        self.onSearch = onSearch
         self.onSelectTab = onSelectTab
     }
 
@@ -92,10 +101,9 @@ public struct ConversationHistoryView: View {
                 .frame(height: 41)
                 .focused($isSearchFocused)
                 .submitLabel(.search)
+                .onSubmit(performSearch)
 
-            Button {
-                isSearchFocused = true
-            } label: {
+            Button(action: performSearch) {
                 Text("⌕")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Color.hopesTextPrimary)
@@ -116,6 +124,24 @@ public struct ConversationHistoryView: View {
     private var conversationList: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
+                if isLoading {
+                    ProgressView("대화 목록을 불러오는 중...")
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 32)
+                } else if let errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(Color.hopesDanger)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 32)
+                } else if conversations.isEmpty {
+                    Text("아직 저장된 대화가 없어요.")
+                        .font(.footnote)
+                        .foregroundStyle(Color.hopesTextPlaceholder)
+                        .frame(maxWidth: .infinity)
+                        .padding(.top, 32)
+                }
+
                 conversationSection(
                     title: "지난 7일",
                     conversations: filteredConversations(for: .recent)
@@ -149,9 +175,7 @@ public struct ConversationHistoryView: View {
                     Text(conversation.title)
                         .font(.footnote.weight(.medium))
                         .foregroundStyle(
-                            conversation.title == Self.sampleConversations.first?.title
-                                ? Color.hopesTextPrimary
-                                : Color.hopesTextSecondary
+                            Color.hopesTextPrimary
                         )
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -186,18 +210,19 @@ public struct ConversationHistoryView: View {
         query.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
-    public static let sampleConversations: [Conversation] = [
-        Conversation(title: "기숙사 하루 일과가 어떻게 돼?", period: .recent),
-        Conversation(title: "전공 선택은 어떻게 하는 게 좋...", period: .recent),
-        Conversation(title: "여기랑 대덕중에 누가 더 좋음", period: .recent),
-        Conversation(title: "입학하려면 뭘 준비해야 해?", period: .older),
-        Conversation(title: "과랑 전공이랑 뭐가 다름", period: .older),
-        Conversation(title: "후배한테 해주고 싶은 조언 있어?", period: .older),
-        Conversation(title: "가장 예쁜 사람 누구?", period: .older),
-    ]
+    private func performSearch() {
+        isSearchFocused = false
+        onSearch(trimmedQuery.isEmpty ? nil : trimmedQuery)
+    }
+
 }
 
 #Preview("지난 대화") {
-    ConversationHistoryView()
+    ConversationHistoryView(
+        conversations: [
+            .init(id: 1, title: "기숙사 하루 일과가 어떻게 돼?", period: .recent),
+            .init(id: 2, title: "입학하려면 뭘 준비해야 해?", period: .older),
+        ]
+    )
         .frame(width: 402, height: 874)
 }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -31,6 +31,10 @@ public struct LoginFlowView: View {
     @State private var chatReply = ""
     @State private var profileName = "임서하"
     @State private var profileIntroduction = ""
+    @State private var conversations: [ConversationHistoryView.Conversation] = []
+    @State private var isLoadingConversations = false
+    @State private var conversationErrorMessage: String?
+    @State private var selectedConversationID: Int64?
 
     private let onLogin: () -> Void
     private let onSignUp: (SignUpFormData) -> Void
@@ -175,12 +179,19 @@ public struct LoginFlowView: View {
 
             case .conversationHistory:
                 ConversationHistoryView(
+                    conversations: conversations,
+                    isLoading: isLoadingConversations,
+                    errorMessage: conversationErrorMessage,
                     onNewConversation: {
                         chatMessage = ""
                         transition(to: .chatHome)
                     },
-                    onSelectConversation: { _ in
+                    onSelectConversation: { conversation in
+                        selectedConversationID = conversation.id
                         transition(to: .chatDetail)
+                    },
+                    onSearch: { searchKeyword in
+                        loadConversations(searchKeyword: searchKeyword)
                     },
                     onSelectTab: navigateFromTab
                 )
@@ -279,12 +290,56 @@ public struct LoginFlowView: View {
                     .transition(.move(edge: .trailing))
             }
         }
+        .task {
+            if screen == .chatHome || screen == .conversationHistory {
+                loadConversations()
+            }
+        }
     }
 
     private func transition(to screen: Screen) {
         withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
             self.screen = screen
         }
+        if screen == .chatHome || screen == .conversationHistory {
+            loadConversations()
+        }
+    }
+
+    private func loadConversations(searchKeyword: String? = nil) {
+        guard !isLoadingConversations else { return }
+        isLoadingConversations = true
+        conversationErrorMessage = nil
+        Task {
+            do {
+                let response = try await HopesAPIClient.shared.main(searchKeyword: searchKeyword)
+                let mappedConversations = response.chatList.map { summary in
+                    ConversationHistoryView.Conversation(
+                        id: summary.id,
+                        title: summary.title,
+                        period: conversationPeriod(for: summary.updatedAt)
+                    )
+                }
+                await MainActor.run {
+                    conversations = mappedConversations
+                    isLoadingConversations = false
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingConversations = false
+                    conversationErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func conversationPeriod(for updatedAt: String) -> ConversationHistoryView.Conversation.Period {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let date = formatter.date(from: updatedAt)
+            ?? ISO8601DateFormatter().date(from: updatedAt)
+        guard let date else { return .older }
+        return date >= Date().addingTimeInterval(-7 * 24 * 60 * 60) ? .recent : .older
     }
 
     private func login() {

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -27,6 +27,16 @@ func passwordPolicyMatchesServerRegex() {
 }
 
 @Test
+func mainResponseMatchesServerPayload() throws {
+    let payload = Data(#"{"chatList":[{"id":42,"title":"기숙사 생활","updatedAt":"2026-08-13T14:00:00Z"}],"newChat":false,"searchKeyword":null,"page":0,"size":50,"hasNext":false}"#.utf8)
+    let response = try JSONDecoder().decode(MainResponse.self, from: payload)
+
+    #expect(response.chatList.first?.id == 42)
+    #expect(response.chatList.first?.title == "기숙사 생활")
+    #expect(!response.hasNext)
+}
+
+@Test
 func logoMetricsMatchFigma() {
     #expect(HopesMetrics.smallCornerRadius == 12)
 }


### PR DESCRIPTION
## 변경 사항
- Keychain의 Bearer 토큰으로 실제 `/api/main`을 호출합니다.
- 서버 DB의 `chatList`를 지난 대화 화면에 표시합니다.
- 샘플 대화 목록을 제거했습니다.
- 대화 ID와 수정 시각을 보존하고 최근 7일을 분류합니다.
- 서버 검색 파라미터와 검색 UI를 연결했습니다.
- 로딩·빈 목록·인증 오류·서버 오류 상태를 처리합니다.

## 실서버 검증
- `GET /api/main?page=0&size=50` 인증 전 401 응답 확인
- 앱은 로그인/가입으로 저장된 실제 토큰을 Authorization 헤더에 적용

## 테스트
- swift test: 26개 통과
- iPhone 17 Pro 시뮬레이터 빌드 및 실행 성공

Closes #76