### PR TITLE
fix: 설정 화면 다크 모드 항목 제거

### DIFF
--- a/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
@@ -2,29 +2,21 @@ import SwiftUI
 
 public struct GeneralSettingsView: View {
     @State private var selectedTab: HopesTab = .settings
-    @State private var isDarkModeEnabled: Bool
-    @State private var savedDarkModeEnabled: Bool
 
     private let onBack: () -> Void
     private let onDone: () -> Void
     private let onBackToChat: () -> Void
-    private let onSave: (Bool) -> Void
     private let onSelectTab: (HopesTab) -> Void
 
     public init(
-        isDarkModeEnabled: Bool = false,
         onBack: @escaping () -> Void = {},
         onDone: @escaping () -> Void = {},
         onBackToChat: @escaping () -> Void = {},
-        onSave: @escaping (Bool) -> Void = { _ in },
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
-        _isDarkModeEnabled = State(initialValue: isDarkModeEnabled)
-        _savedDarkModeEnabled = State(initialValue: isDarkModeEnabled)
         self.onBack = onBack
         self.onDone = onDone
         self.onBackToChat = onBackToChat
-        self.onSave = onSave
         self.onSelectTab = onSelectTab
     }
 
@@ -97,45 +89,12 @@ public struct GeneralSettingsView: View {
                     .padding(.leading, 24)
                     .padding(.top, 28)
 
-                darkModeRow
-                    .padding(.horizontal, 10)
-                    .padding(.top, 28)
-
                 backToChatRow
                     .padding(.horizontal, 10)
-                    .padding(.top, 16)
+                    .padding(.top, 28)
             }
         }
-        .frame(height: 270)
-    }
-
-    private var darkModeRow: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 5) {
-                Text("다크 모드")
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(Color.hopesTextPrimary)
-
-                Text("시스템 설정에 맞춰 전환")
-                    .font(.caption)
-                    .foregroundStyle(Color.hopesTextSecondary)
-            }
-
-            Spacer()
-
-            Toggle("다크 모드", isOn: $isDarkModeEnabled)
-                .labelsHidden()
-                .tint(.hopesBrandPrimary)
-        }
-        .padding(.horizontal, 20)
-        .frame(height: 78)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: 18))
-        .overlay {
-            RoundedRectangle(cornerRadius: 18)
-                .stroke(Color.hopesBorder, lineWidth: 1)
-        }
-        .shadow(color: Color.black.opacity(0.045), radius: 7, y: 4)
+        .frame(height: 180)
     }
 
     private var backToChatRow: some View {
@@ -174,35 +133,23 @@ public struct GeneralSettingsView: View {
     private var actionButtons: some View {
         HStack(spacing: 14) {
             HopesButton(
-                "저장",
+                "완료",
                 size: .regular,
                 width: .fixed(170),
-                action: save
+                action: onDone
             )
 
             HopesButton(
-                "초기화",
+                "뒤로",
                 variant: .secondary,
                 size: .regular,
                 width: .fixed(170),
-                action: reset
+                action: onBack
             )
         }
     }
 
-    private func save() {
-        savedDarkModeEnabled = isDarkModeEnabled
-        onSave(isDarkModeEnabled)
-    }
-
-    private func reset() {
-        isDarkModeEnabled = false
-    }
-
     private func complete() {
-        if savedDarkModeEnabled != isDarkModeEnabled {
-            save()
-        }
         onDone()
     }
 }

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 public struct SettingsView: View {
     @State private var selectedTab: HopesTab = .settings
-    @State private var isDarkModeEnabled = false
 
     private let contactEmail: String
     private let onBackToChat: () -> Void
@@ -58,12 +57,6 @@ public struct SettingsView: View {
             .padding(.leading, 37)
             .padding(.top, 217)
 
-            darkModeRow
-                .frame(width: 314)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.leading, 39)
-                .padding(.top, 307)
-
             HopesButton(
                 "로그아웃",
                 variant: .danger,
@@ -72,7 +65,7 @@ public struct SettingsView: View {
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 29)
-            .padding(.top, 397)
+            .padding(.top, 307)
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -93,40 +86,6 @@ public struct SettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var darkModeRow: some View {
-        HStack(spacing: 12) {
-            Button(action: onOpenGeneral) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("다크 모드")
-                        .font(.callout.weight(.semibold))
-                        .foregroundStyle(Color.hopesTextPrimary)
-
-                    Text("시스템 설정에 맞춰 전환")
-                        .font(.caption)
-                        .foregroundStyle(Color.hopesTextSecondary)
-                }
-                .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityHint("일반 설정 화면을 엽니다")
-
-            Spacer(minLength: 8)
-
-            Toggle("다크 모드", isOn: $isDarkModeEnabled)
-                .labelsHidden()
-                .frame(width: 44)
-                .scaleEffect(0.78)
-        }
-        .padding(.horizontal, 20)
-        .frame(height: 64)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
-                .stroke(Color.hopesBorder, lineWidth: 1)
-        }
-        .shadow(color: Color.black.opacity(0.045), radius: 7, y: 4)
-    }
 }
 
 #Preview("설정") {

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -163,7 +163,6 @@ func settingsViewCanBeConstructed() {
 @MainActor
 func generalSettingsViewCanBeConstructed() {
     _ = GeneralSettingsView()
-    _ = GeneralSettingsView(isDarkModeEnabled: true)
     _ = LoginFlowView(isGeneralSettingsInitiallyOpen: true)
 }
 


### PR DESCRIPTION
## 변경 사항
- 설정 메인 화면의 다크 모드 토글을 제거했습니다.
- 일반 설정 상세 화면의 다크 모드 토글과 상태를 제거했습니다.
- 일반 설정의 채팅 복귀 기능은 유지했습니다.
- 관련 테스트 API를 정리했습니다.

## 테스트
- swift test: 26개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #78