### PR TITLE
feat: 실서버 채팅 생성 및 AI 답변 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -67,6 +67,39 @@ public struct MainResponse: Decodable, Sendable, Equatable {
     public let hasNext: Bool
 }
 
+public struct CreateChatRequest: Encodable, Sendable {
+    public let title: String?
+
+    public init(title: String? = nil) {
+        self.title = title
+    }
+}
+
+public struct SendMessageRequest: Encodable, Sendable {
+    public let content: String
+}
+
+public struct MessageResponse: Decodable, Sendable, Equatable, Identifiable {
+    public enum Role: String, Decodable, Sendable {
+        case user = "USER"
+        case assistant = "ASSISTANT"
+    }
+
+    public let id: Int64
+    public let role: Role
+    public let content: String
+    public let createdAt: String
+}
+
+public struct ChatResponse: Decodable, Sendable, Equatable {
+    public let id: Int64
+    public let title: String
+    public let messages: [MessageResponse]
+    public let messagePage: Int
+    public let messageSize: Int
+    public let hasMoreMessages: Bool
+}
+
 public enum HopesAPIError: LocalizedError, Sendable, Equatable {
     case invalidResponse
     case unauthorized(String)

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -101,6 +101,48 @@ public actor HopesAPIClient {
         return try await request(url: url, method: "GET", body: nil, requiresAuthentication: true)
     }
 
+    public func createChat(title: String? = nil) async throws -> ChatResponse {
+        try await request(
+            path: "/api/chats",
+            method: "POST",
+            body: CreateChatRequest(title: title),
+            requiresAuthentication: true
+        )
+    }
+
+    public func sendMessage(chatID: Int64, content: String) async throws -> ChatResponse {
+        guard content.count <= 12_000 else {
+            throw HopesAPIError.server(statusCode: 400, message: "질문은 12,000자 이하여야 합니다")
+        }
+        guard let url = URL(string: "/api/chats/\(chatID)/messages", relativeTo: baseURL) else {
+            throw HopesAPIError.invalidResponse
+        }
+        return try await request(
+            url: url,
+            method: "POST",
+            body: try encoder.encode(SendMessageRequest(content: content)),
+            requiresAuthentication: true,
+            timeoutInterval: 70
+        )
+    }
+
+    public func chat(id: Int64, messagePage: Int = 0, messageSize: Int = 50) async throws -> ChatResponse {
+        guard var components = URLComponents(
+            url: baseURL.appending(path: "/api/chats/\(id)"),
+            resolvingAgainstBaseURL: false
+        ) else {
+            throw HopesAPIError.invalidResponse
+        }
+        components.queryItems = [
+            URLQueryItem(name: "messagePage", value: String(messagePage)),
+            URLQueryItem(name: "messageSize", value: String(messageSize)),
+        ]
+        guard let url = components.url else {
+            throw HopesAPIError.invalidResponse
+        }
+        return try await request(url: url, method: "GET", body: nil, requiresAuthentication: true)
+    }
+
     private func request<Response: Decodable, Body: Encodable>(
         path: String,
         method: String,
@@ -123,13 +165,14 @@ public actor HopesAPIClient {
         url: URL,
         method: String,
         body: Data?,
-        requiresAuthentication: Bool
+        requiresAuthentication: Bool,
+        timeoutInterval: TimeInterval = 20
     ) async throws -> Response {
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
-        request.timeoutInterval = 20
+        request.timeoutInterval = timeoutInterval
         request.httpBody = body
 
         if requiresAuthentication {

--- a/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
@@ -2,18 +2,24 @@ import SwiftUI
 
 public struct ChatDetailView: View {
     @State private var selectedTab: HopesTab = .chat
-    @State private var isSaved = false
-    @State private var isLiked = false
     @Binding private var reply: String
 
+    private let title: String
+    private let messages: [MessageResponse]
+    private let isLoading: Bool
+    private let isSending: Bool
+    private let errorMessage: String?
     private let onBack: () -> Void
-    private let onShowSources: () -> Void
     private let onSend: (String) -> Void
-    private let onShare: () -> Void
     private let onSelectTab: (HopesTab) -> Void
 
     public init(
         reply: Binding<String>,
+        title: String = "새 대화",
+        messages: [MessageResponse] = [],
+        isLoading: Bool = false,
+        isSending: Bool = false,
+        errorMessage: String? = nil,
         onBack: @escaping () -> Void = {},
         onShowSources: @escaping () -> Void = {},
         onSend: @escaping (String) -> Void = { _ in },
@@ -21,10 +27,13 @@ public struct ChatDetailView: View {
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         _reply = reply
+        self.title = title
+        self.messages = messages
+        self.isLoading = isLoading
+        self.isSending = isSending
+        self.errorMessage = errorMessage
         self.onBack = onBack
-        self.onShowSources = onShowSources
         self.onSend = onSend
-        self.onShare = onShare
         self.onSelectTab = onSelectTab
     }
 
@@ -36,24 +45,13 @@ public struct ChatDetailView: View {
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
                 .padding(.top, 72)
 
-            userBubble
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 150)
-
-            answerBubble
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 232)
-
-            responseActions
-                .padding(.leading, 44)
-                .padding(.top, 364)
-
-            sourceCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 430)
+            messageList
+                .padding(.top, 132)
+                .padding(.bottom, 158)
 
             composer
-                .padding(.top, 716)
+                .frame(maxHeight: .infinity, alignment: .bottom)
+                .padding(.bottom, 84)
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -62,7 +60,7 @@ public struct ChatDetailView: View {
     }
 
     private var header: some View {
-        HStack(alignment: .top, spacing: 12) {
+        HStack(spacing: 12) {
             Button(action: onBack) {
                 Image(systemName: "chevron.left")
                     .font(.title3.weight(.semibold))
@@ -71,130 +69,93 @@ public struct ChatDetailView: View {
                     .background(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 13))
                     .overlay {
-                        RoundedRectangle(cornerRadius: 13)
-                            .stroke(Color.hopesBorder, lineWidth: 1)
+                        RoundedRectangle(cornerRadius: 13).stroke(Color.hopesBorder, lineWidth: 1)
                     }
             }
             .buttonStyle(.plain)
             .accessibilityLabel("뒤로")
 
             VStack(alignment: .leading, spacing: 1) {
-                Text("기숙사 생활")
-                    .font(.system(size: 27, weight: .bold))
+                Text(title)
+                    .font(.system(size: 24, weight: .bold))
                     .foregroundStyle(Color.hopesTextPrimary)
-
-                Text("선배 답변 · 실제 경험 기반")
+                    .lineLimit(1)
+                Text("홉스 AI 답변")
                     .font(.footnote)
                     .foregroundStyle(Color.hopesTextSecondary)
             }
+            Spacer()
+        }
+    }
 
-            Spacer(minLength: 8)
+    private var messageList: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 12) {
+                    if isLoading {
+                        ProgressView("대화를 불러오는 중...")
+                            .padding(.top, 32)
+                    } else if messages.isEmpty {
+                        Text("질문을 보내면 AI 답변이 여기에 표시돼요.")
+                            .font(.footnote)
+                            .foregroundStyle(Color.hopesTextPlaceholder)
+                            .padding(.top, 32)
+                    }
 
-            HopesButton(
-                isSaved ? "저장됨" : "저장",
-                variant: .secondary,
-                size: .small,
-                width: .fixed(isSaved ? 64 : 54)
-            ) {
-                isSaved.toggle()
+                    ForEach(messages) { message in
+                        messageBubble(message)
+                            .id(message.id)
+                    }
+
+                    if isSending {
+                        HStack(spacing: 8) {
+                            ProgressView()
+                            Text("AI가 답변을 만들고 있어요.")
+                                .font(.footnote)
+                                .foregroundStyle(Color.hopesTextSecondary)
+                            Spacer()
+                        }
+                        .padding(16)
+                        .background(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
+                    }
+
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .font(.footnote)
+                            .foregroundStyle(Color.hopesDanger)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            }
+            .scrollIndicators(.hidden)
+            .onChange(of: messages.count) {
+                if let lastID = messages.last?.id {
+                    withAnimation { proxy.scrollTo(lastID, anchor: .bottom) }
+                }
             }
         }
     }
 
-    private var userBubble: some View {
+    private func messageBubble(_ message: MessageResponse) -> some View {
         HStack {
-            Spacer(minLength: 70)
-
-            Text("기숙사 하루 일과가 어떻게 돼?")
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 20)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .frame(height: 58)
-                .background(Color.hopesBrandPrimary)
+            if message.role == .user { Spacer(minLength: 64) }
+            Text(message.content)
+                .font(.subheadline)
+                .foregroundStyle(message.role == .user ? .white : Color.hopesTextPrimary)
+                .lineSpacing(2)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 14)
+                .background(message.role == .user ? Color.hopesBrandPrimary : .white)
                 .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
-        }
-    }
-
-    private var answerBubble: some View {
-        Text(
-            "평일은 저녁 식사 후 자습, 점호 순서로 흘러가요. "
-                + "처음엔 빠듯하지만 일주일 정도 지나면 개인 루틴이 잡혀요."
-        )
-        .font(.subheadline)
-        .foregroundStyle(Color.hopesTextPrimary)
-        .lineSpacing(2)
-        .padding(.horizontal, 20)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 110)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
-                .stroke(Color.hopesBorder, lineWidth: 1)
-        }
-    }
-
-    private var responseActions: some View {
-        HStack(spacing: 12) {
-            HopesButton(
-                isLiked ? "좋아요!" : "좋아요",
-                variant: .secondary,
-                size: .small,
-                width: .fixed(isLiked ? 84 : 76)
-            ) {
-                isLiked.toggle()
-            }
-
-            HopesButton(
-                "더 물어보기",
-                size: .small,
-                width: .fixed(104)
-            ) {
-                reply = "기숙사 생활에 대해 더 알려줘."
-            }
-
-            HopesButton(
-                "공유",
-                variant: .secondary,
-                size: .small,
-                width: .fixed(76),
-                action: onShare
-            )
-        }
-    }
-
-    private var sourceCard: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 10) {
-                Text("답변 근거")
-                    .font(.callout.weight(.bold))
-                    .foregroundStyle(Color.hopesTextPrimary)
-
-                Text("점호 시간, 자습실 분위기, 빨래 루틴을 선배 답변에서 정리했어요.")
-                    .font(.footnote)
-                    .foregroundStyle(Color.hopesTextSecondary)
-                    .lineSpacing(2)
-            }
-
-            Spacer(minLength: 0)
-
-            HopesButton(
-                "보기",
-                variant: .secondary,
-                size: .compact,
-                width: .fixed(54),
-                action: onShowSources
-            )
-        }
-        .padding(.horizontal, 20)
-        .frame(maxWidth: .infinity)
-        .frame(height: 106)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
-                .stroke(Color.hopesBorder, lineWidth: 1)
+                .overlay {
+                    if message.role == .assistant {
+                        RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                            .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+                }
+            if message.role == .assistant { Spacer(minLength: 40) }
         }
     }
 
@@ -202,38 +163,27 @@ public struct ChatDetailView: View {
         HStack(spacing: 14) {
             TextField("추가 질문 입력", text: $reply)
                 .font(.footnote)
-                .foregroundStyle(Color.hopesTextPrimary)
                 .padding(.horizontal, 20)
                 .frame(height: 44)
                 .background(Color.hopesInputBackground)
                 .clipShape(RoundedRectangle(cornerRadius: 16))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 16)
-                        .stroke(Color.hopesBorder, lineWidth: 1)
-                }
+                .overlay { RoundedRectangle(cornerRadius: 16).stroke(Color.hopesBorder, lineWidth: 1) }
                 .onSubmit(sendReply)
+                .disabled(isSending)
 
-            Button("전송", action: sendReply)
+            Button(isSending ? "전송 중" : "전송", action: sendReply)
                 .font(.footnote.weight(.semibold))
                 .foregroundStyle(.white)
-                .frame(width: 58, height: 44)
+                .frame(width: 64, height: 44)
                 .background(Color.hopesBrandPrimary)
-                .clipShape(
-                    RoundedRectangle(
-                        cornerRadius: HopesMetrics.controlCornerRadius
-                    )
-                )
-                .disabled(trimmedReply.isEmpty)
-                .opacity(trimmedReply.isEmpty ? 0.45 : 1)
+                .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+                .disabled(trimmedReply.isEmpty || isSending)
+                .opacity(trimmedReply.isEmpty || isSending ? 0.45 : 1)
         }
         .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
         .frame(height: 74)
         .background(.white)
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(Color.hopesBorder)
-                .frame(height: 1)
-        }
+        .overlay(alignment: .top) { Rectangle().fill(Color.hopesBorder).frame(height: 1) }
     }
 
     private var trimmedReply: String {
@@ -241,18 +191,15 @@ public struct ChatDetailView: View {
     }
 
     private func sendReply() {
-        guard !trimmedReply.isEmpty else {
-            return
-        }
-
-        onSend(trimmedReply)
+        guard !trimmedReply.isEmpty, trimmedReply.count <= 12_000, !isSending else { return }
+        let content = trimmedReply
         reply = ""
+        onSend(content)
     }
 }
 
 #Preview("채팅 상세") {
     @Previewable @State var reply = ""
-
     ChatDetailView(reply: $reply)
         .frame(width: 402, height: 874)
 }

--- a/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
@@ -135,7 +135,7 @@ public struct ChatHomeView: View {
     }
 
     private func sendMessage() {
-        guard !trimmedMessage.isEmpty else {
+        guard !trimmedMessage.isEmpty, trimmedMessage.count <= 12_000 else {
             return
         }
 

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -35,6 +35,10 @@ public struct LoginFlowView: View {
     @State private var isLoadingConversations = false
     @State private var conversationErrorMessage: String?
     @State private var selectedConversationID: Int64?
+    @State private var activeChat: ChatResponse?
+    @State private var isLoadingChat = false
+    @State private var isSendingMessage = false
+    @State private var chatErrorMessage: String?
 
     private let onLogin: () -> Void
     private let onSignUp: (SignUpFormData) -> Void
@@ -144,8 +148,11 @@ public struct LoginFlowView: View {
             case .chatHome:
                 ChatHomeView(
                     message: $chatMessage,
-                    onSend: { _ in
-                        transition(to: .chatDetail)
+                    onNewChat: {
+                        startNewChat()
+                    },
+                    onSend: { message in
+                        startNewChat(with: message)
                     },
                     onSelectTab: navigateFromTab
                 )
@@ -154,11 +161,19 @@ public struct LoginFlowView: View {
             case .chatDetail:
                 ChatDetailView(
                     reply: $chatReply,
+                    title: activeChat?.title ?? "새 대화",
+                    messages: activeChat?.messages ?? [],
+                    isLoading: isLoadingChat,
+                    isSending: isSendingMessage,
+                    errorMessage: chatErrorMessage,
                     onBack: {
                         transition(to: .chatHome)
                     },
                     onShowSources: {
                         transition(to: .answerEvidence)
+                    },
+                    onSend: { message in
+                        sendMessage(message)
                     },
                     onSelectTab: navigateFromTab
                 )
@@ -184,11 +199,12 @@ public struct LoginFlowView: View {
                     errorMessage: conversationErrorMessage,
                     onNewConversation: {
                         chatMessage = ""
-                        transition(to: .chatHome)
+                        startNewChat()
                     },
                     onSelectConversation: { conversation in
                         selectedConversationID = conversation.id
                         transition(to: .chatDetail)
+                        loadChat(id: conversation.id)
                     },
                     onSearch: { searchKeyword in
                         loadConversations(searchKeyword: searchKeyword)
@@ -328,6 +344,81 @@ public struct LoginFlowView: View {
                 await MainActor.run {
                     isLoadingConversations = false
                     conversationErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func startNewChat(with initialMessage: String? = nil) {
+        guard !isLoadingChat else { return }
+        isLoadingChat = true
+        chatErrorMessage = nil
+        activeChat = nil
+        transition(to: .chatDetail)
+        Task {
+            do {
+                let createdChat = try await HopesAPIClient.shared.createChat(title: nil)
+                await MainActor.run {
+                    activeChat = createdChat
+                    selectedConversationID = createdChat.id
+                    isLoadingChat = false
+                }
+                if let initialMessage, !initialMessage.isEmpty {
+                    await MainActor.run { chatMessage = "" }
+                    sendMessage(initialMessage)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingChat = false
+                    chatErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func loadChat(id: Int64) {
+        guard !isLoadingChat else { return }
+        isLoadingChat = true
+        chatErrorMessage = nil
+        activeChat = nil
+        Task {
+            do {
+                let chat = try await HopesAPIClient.shared.chat(id: id)
+                await MainActor.run {
+                    activeChat = chat
+                    isLoadingChat = false
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingChat = false
+                    chatErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func sendMessage(_ content: String) {
+        guard let chatID = activeChat?.id ?? selectedConversationID,
+              !isSendingMessage
+        else { return }
+        isSendingMessage = true
+        chatErrorMessage = nil
+        Task {
+            do {
+                let updatedChat = try await HopesAPIClient.shared.sendMessage(
+                    chatID: chatID,
+                    content: content
+                )
+                await MainActor.run {
+                    activeChat = updatedChat
+                    selectedConversationID = updatedChat.id
+                    isSendingMessage = false
+                    loadConversations()
+                }
+            } catch {
+                await MainActor.run {
+                    isSendingMessage = false
+                    chatErrorMessage = error.localizedDescription
                 }
             }
         }

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -37,6 +37,22 @@ func mainResponseMatchesServerPayload() throws {
 }
 
 @Test
+func chatResponseMatchesServerPayload() throws {
+    let payload = Data(#"{"id":7,"title":"기숙사 생활","messages":[{"id":10,"role":"USER","content":"점호가 몇 시야?","createdAt":"2026-08-13T14:00:00Z"},{"id":11,"role":"ASSISTANT","content":"점호 시간은 생활관 공지를 확인해 주세요.","createdAt":"2026-08-13T14:00:01Z"}],"messagePage":0,"messageSize":50,"hasMoreMessages":false}"#.utf8)
+    let response = try JSONDecoder().decode(ChatResponse.self, from: payload)
+
+    #expect(response.id == 7)
+    #expect(response.messages.map(\.role) == [.user, .assistant])
+    #expect(response.messages.last?.content == "점호 시간은 생활관 공지를 확인해 주세요.")
+}
+
+@Test
+func chatMessageRolesMatchBackendEnum() {
+    #expect(MessageResponse.Role.user.rawValue == "USER")
+    #expect(MessageResponse.Role.assistant.rawValue == "ASSISTANT")
+}
+
+@Test
 func logoMetricsMatchFigma() {
     #expect(HopesMetrics.smallCornerRadius == 12)
 }


### PR DESCRIPTION
## 변경 사항
- 실제 `/api/chats`로 새 대화를 생성합니다.
- 서버가 발급한 채팅 ID로 메시지를 전송합니다.
- 서버 DB에 저장된 USER/ASSISTANT 메시지 배열을 그대로 표시합니다.
- 지난 대화 선택 시 실제 상세 API를 호출합니다.
- AI 응답 중 로딩과 서버 오류를 표시합니다.
- 백엔드 구현에 맞춰 메시지 전송 타임아웃을 70초로 설정했습니다.
- 서버와 동일하게 질문을 12,000자로 제한합니다.

## 백엔드 대조
- `hopes-server-v1`의 swagger-api-spec 브랜치 Controller, DTO, ChatService, 통합 테스트 확인
- Gemini 실패 시 질문도 저장되지 않아 그대로 재시도 가능한 동작 확인

## 테스트
- swift test: 28개 통과
- iPhone 17 Pro 시뮬레이터 빌드 및 실행 성공

Closes #80