### PR TITLE
feat: 실서버 마이페이지 및 설정 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -100,6 +100,37 @@ public struct ChatResponse: Decodable, Sendable, Equatable {
     public let hasMoreMessages: Bool
 }
 
+public struct UserResponse: Decodable, Sendable, Equatable {
+    public let username: String
+    public let email: String
+    public let nickname: String
+    public let profileInfo: String
+    public let profileImage: String?
+    public let gender: String?
+    public let major: String?
+    public let cohort: Int?
+}
+
+public struct MyPageUpdateRequest: Encodable, Sendable {
+    public let username: String?
+    public let nickname: String?
+    public let profileInfo: String?
+    public let profileImage: String?
+}
+
+public struct SettingUpdateRequest: Encodable, Sendable {
+    public let customPrompt: String?
+    public let deleteAllChats: Bool
+}
+
+public struct SettingMainResponse: Decodable, Sendable, Equatable {
+    public let accountSetting: UserResponse
+    public let theme: String
+    public let customPrompt: String
+    public let logout: Bool
+    public let inquiry: Bool
+}
+
 public enum HopesAPIError: LocalizedError, Sendable, Equatable {
     case invalidResponse
     case unauthorized(String)

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -143,6 +143,52 @@ public actor HopesAPIClient {
         return try await request(url: url, method: "GET", body: nil, requiresAuthentication: true)
     }
 
+    public func myPage() async throws -> UserResponse {
+        try await authenticatedGet(path: "/api/mypage")
+    }
+
+    public func updateMyPage(
+        username: String?,
+        nickname: String?,
+        profileInfo: String?,
+        profileImage: String? = nil
+    ) async throws -> UserResponse {
+        try await request(
+            path: "/api/mypage",
+            method: "PATCH",
+            body: MyPageUpdateRequest(
+                username: username,
+                nickname: nickname,
+                profileInfo: profileInfo,
+                profileImage: profileImage
+            ),
+            requiresAuthentication: true
+        )
+    }
+
+    public func settings() async throws -> SettingMainResponse {
+        try await authenticatedGet(path: "/api/setting/main")
+    }
+
+    public func updateSettings(
+        customPrompt: String?,
+        deleteAllChats: Bool = false
+    ) async throws -> SettingMainResponse {
+        try await request(
+            path: "/api/setting",
+            method: "PATCH",
+            body: SettingUpdateRequest(customPrompt: customPrompt, deleteAllChats: deleteAllChats),
+            requiresAuthentication: true
+        )
+    }
+
+    private func authenticatedGet<Response: Decodable>(path: String) async throws -> Response {
+        guard let url = URL(string: path, relativeTo: baseURL) else {
+            throw HopesAPIError.invalidResponse
+        }
+        return try await request(url: url, method: "GET", body: nil, requiresAuthentication: true)
+    }
+
     private func request<Response: Decodable, Body: Encodable>(
         path: String,
         method: String,

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -31,6 +31,14 @@ public struct LoginFlowView: View {
     @State private var chatReply = ""
     @State private var profileName = "임서하"
     @State private var profileIntroduction = ""
+    @State private var profileEmail = ""
+    @State private var profileMajor = ""
+    @State private var isLoadingProfile = false
+    @State private var isSavingProfile = false
+    @State private var profileErrorMessage: String?
+    @State private var customPrompt = ""
+    @State private var isSavingSettings = false
+    @State private var settingsErrorMessage: String?
     @State private var conversations: [ConversationHistoryView.Conversation] = []
     @State private var isLoadingConversations = false
     @State private var conversationErrorMessage: String?
@@ -217,8 +225,16 @@ public struct LoginFlowView: View {
                 MyPageView(
                     name: $profileName,
                     introduction: $profileIntroduction,
+                    email: profileEmail,
+                    major: profileMajor,
+                    isLoading: isLoadingProfile,
+                    isSaving: isSavingProfile,
+                    errorMessage: profileErrorMessage,
                     onBackToChat: {
                         transition(to: .settings)
+                    },
+                    onSave: { profile in
+                        saveProfile(profile)
                     },
                     onOpenAccountInfo: {
                         transition(to: .accountInfo)
@@ -265,6 +281,9 @@ public struct LoginFlowView: View {
 
             case .personalSettings:
                 PersonalSettingsView(
+                    systemPrompt: customPrompt,
+                    isSaving: isSavingSettings,
+                    errorMessage: settingsErrorMessage,
                     onBack: {
                         transition(to: .settings)
                     },
@@ -274,8 +293,12 @@ public struct LoginFlowView: View {
                     onBackToChat: {
                         transition(to: .chatHome)
                     },
+                    onSavePrompt: { prompt in
+                        saveSettings(prompt: prompt)
+                    },
                     onSelectTab: navigateFromTab
                 )
+                    .id(customPrompt)
                     .transition(.move(edge: .trailing))
 
             case .contact:
@@ -319,7 +342,97 @@ public struct LoginFlowView: View {
         }
         if screen == .chatHome || screen == .conversationHistory {
             loadConversations()
+        } else if screen == .myPage {
+            loadProfile()
+        } else if screen == .settings || screen == .personalSettings {
+            loadSettings()
         }
+    }
+
+    private func loadProfile() {
+        guard !isLoadingProfile else { return }
+        isLoadingProfile = true
+        profileErrorMessage = nil
+        Task {
+            do {
+                let profile = try await HopesAPIClient.shared.myPage()
+                await MainActor.run {
+                    apply(profile: profile)
+                    isLoadingProfile = false
+                }
+            } catch {
+                await MainActor.run {
+                    isLoadingProfile = false
+                    profileErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func saveProfile(_ profile: MyPageView.Profile) {
+        guard !isSavingProfile else { return }
+        isSavingProfile = true
+        profileErrorMessage = nil
+        Task {
+            do {
+                let updated = try await HopesAPIClient.shared.updateMyPage(
+                    username: profile.name,
+                    nickname: nil,
+                    profileInfo: profile.introduction
+                )
+                await MainActor.run {
+                    apply(profile: updated)
+                    isSavingProfile = false
+                }
+            } catch {
+                await MainActor.run {
+                    isSavingProfile = false
+                    profileErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func loadSettings() {
+        Task {
+            do {
+                let settings = try await HopesAPIClient.shared.settings()
+                await MainActor.run {
+                    customPrompt = settings.customPrompt
+                    apply(profile: settings.accountSetting)
+                    settingsErrorMessage = nil
+                }
+            } catch {
+                await MainActor.run { settingsErrorMessage = error.localizedDescription }
+            }
+        }
+    }
+
+    private func saveSettings(prompt: String) {
+        guard !isSavingSettings else { return }
+        isSavingSettings = true
+        settingsErrorMessage = nil
+        Task {
+            do {
+                let settings = try await HopesAPIClient.shared.updateSettings(customPrompt: prompt)
+                await MainActor.run {
+                    customPrompt = settings.customPrompt
+                    isSavingSettings = false
+                }
+            } catch {
+                await MainActor.run {
+                    isSavingSettings = false
+                    settingsErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func apply(profile: UserResponse) {
+        profileName = profile.username
+        profileIntroduction = profile.profileInfo
+        profileEmail = profile.email
+        profileMajor = profile.major ?? "미설정"
     }
 
     private func loadConversations(searchKeyword: String? = nil) {

--- a/Sources/HopesDesignSystem/Screens/MyPageView.swift
+++ b/Sources/HopesDesignSystem/Screens/MyPageView.swift
@@ -19,6 +19,9 @@ public struct MyPageView: View {
 
     private let email: String
     private let major: String
+    private let isLoading: Bool
+    private let isSaving: Bool
+    private let errorMessage: String?
     private let onBackToChat: () -> Void
     private let onSave: (Profile) -> Void
     private let onOpenAccountInfo: () -> Void
@@ -29,6 +32,9 @@ public struct MyPageView: View {
         introduction: Binding<String>,
         email: String = "s26055@gsm.hs.kr",
         major: String = "인공지능소프트웨어과",
+        isLoading: Bool = false,
+        isSaving: Bool = false,
+        errorMessage: String? = nil,
         onBackToChat: @escaping () -> Void = {},
         onSave: @escaping (Profile) -> Void = { _ in },
         onOpenAccountInfo: @escaping () -> Void = {},
@@ -44,6 +50,9 @@ public struct MyPageView: View {
         )
         self.email = email
         self.major = major
+        self.isLoading = isLoading
+        self.isSaving = isSaving
+        self.errorMessage = errorMessage
         self.onBackToChat = onBackToChat
         self.onSave = onSave
         self.onOpenAccountInfo = onOpenAccountInfo
@@ -78,15 +87,26 @@ public struct MyPageView: View {
                 .padding(.top, 350)
 
             HopesButton(
-                hasSaved && !hasUnsavedChanges ? "저장됨" : "저장",
+                isSaving ? "저장 중" : "저장",
                 size: .regular,
                 width: .fixed(hasSaved && !hasUnsavedChanges ? 104 : 96),
-                isEnabled: canSave,
+                isEnabled: canSave && !isLoading && !isSaving,
                 action: saveProfile
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 18)
             .padding(.top, 694)
+
+            if isLoading {
+                ProgressView("프로필을 불러오는 중...")
+                    .padding(.top, 660)
+            } else if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesDanger)
+                    .padding(.horizontal, 24)
+                    .padding(.top, 660)
+            }
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -222,10 +242,6 @@ public struct MyPageView: View {
             return
         }
 
-        name = currentProfile.name
-        introduction = currentProfile.introduction
-        lastSavedProfile = currentProfile
-        hasSaved = true
         onSave(currentProfile)
     }
 }

--- a/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
@@ -10,9 +10,13 @@ public struct PersonalSettingsView: View {
     private let onSavePrompt: (String) -> Void
     private let onDeleteAllConversations: () -> Void
     private let onSelectTab: (HopesTab) -> Void
+    private let isSaving: Bool
+    private let errorMessage: String?
 
     public init(
         systemPrompt: String = "",
+        isSaving: Bool = false,
+        errorMessage: String? = nil,
         onBack: @escaping () -> Void = {},
         onDone: @escaping () -> Void = {},
         onBackToChat: @escaping () -> Void = {},
@@ -21,6 +25,8 @@ public struct PersonalSettingsView: View {
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         _systemPrompt = State(initialValue: systemPrompt)
+        self.isSaving = isSaving
+        self.errorMessage = errorMessage
         self.onBack = onBack
         self.onDone = onDone
         self.onBackToChat = onBackToChat
@@ -94,14 +100,22 @@ public struct PersonalSettingsView: View {
                     .padding(.top, 16)
 
                 HopesButton(
-                    "프롬프트 저장",
+                    isSaving ? "저장 중" : "프롬프트 저장",
                     size: .regular,
                     width: .fixed(100)
                 ) {
                     onSavePrompt(systemPrompt)
                 }
+                .disabled(isSaving)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .padding(.top, 19)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(Color.hopesDanger)
+                        .padding(.top, 10)
+                }
             }
         }
         .frame(height: 408)

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -53,6 +53,16 @@ func chatMessageRolesMatchBackendEnum() {
 }
 
 @Test
+func userAndSettingsResponsesMatchBackendPayloads() throws {
+    let payload = Data(#"{"accountSetting":{"username":"홍길동","email":"s26055@gsm.hs.kr","nickname":"길동","profileInfo":"AI 전공","profileImage":null,"gender":null,"major":"AI","cohort":10},"theme":"LIGHT","customPrompt":"세 문장으로 답해줘","logout":true,"inquiry":true}"#.utf8)
+    let response = try JSONDecoder().decode(SettingMainResponse.self, from: payload)
+
+    #expect(response.accountSetting.email == "s26055@gsm.hs.kr")
+    #expect(response.accountSetting.cohort == 10)
+    #expect(response.customPrompt == "세 문장으로 답해줘")
+}
+
+@Test
 func logoMetricsMatchFigma() {
     #expect(HopesMetrics.smallCornerRadius == 12)
 }


### PR DESCRIPTION
## 변경 사항
- 실제 `/api/mypage` 조회·수정을 연결했습니다.
- 서버 DB의 이메일·전공·이름·프로필 정보를 표시합니다.
- 실제 `/api/setting/main` 조회를 연결했습니다.
- 개인 프롬프트를 `/api/setting`으로 저장합니다.
- 서버 성공 응답 이후에만 화면 값을 확정합니다.
- 로딩·저장 중·서버 오류 상태를 처리합니다.

## 검증
- 백엔드 Controller, DTO, UserService 구현 대조
- 실제 API 인증 전 401 응답 확인
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #82