### PR TITLE
feat: [#84] 실서버 문의 및 로그아웃 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -131,6 +131,10 @@ public struct SettingMainResponse: Decodable, Sendable, Equatable {
     public let inquiry: Bool
 }
 
+public struct InquiryRequest: Encodable, Sendable {
+    public let content: String
+}
+
 public enum HopesAPIError: LocalizedError, Sendable, Equatable {
     case invalidResponse
     case unauthorized(String)

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -182,6 +182,26 @@ public actor HopesAPIClient {
         )
     }
 
+    public func submitInquiry(content: String) async throws -> MessageEnvelope {
+        try await request(
+            path: "/api/setting/inquiry",
+            method: "POST",
+            body: InquiryRequest(content: content),
+            requiresAuthentication: true
+        )
+    }
+
+    public func logout() async throws -> MessageEnvelope {
+        let response: MessageEnvelope = try await request(
+            path: "/api/logout",
+            method: "POST",
+            body: EmptyRequest(),
+            requiresAuthentication: true
+        )
+        try await tokenStore.clear()
+        return response
+    }
+
     private func authenticatedGet<Response: Decodable>(path: String) async throws -> Response {
         guard let url = URL(string: path, relativeTo: baseURL) else {
             throw HopesAPIError.invalidResponse
@@ -256,3 +276,5 @@ public actor HopesAPIClient {
         }
     }
 }
+
+private struct EmptyRequest: Encodable {}

--- a/Sources/HopesDesignSystem/Screens/ContactView.swift
+++ b/Sources/HopesDesignSystem/Screens/ContactView.swift
@@ -10,11 +10,15 @@ public struct ContactView: View {
     private let onDone: () -> Void
     private let onSend: (String, String) -> Void
     private let onSelectTab: (HopesTab) -> Void
+    private let isSending: Bool
+    private let errorMessage: String?
 
     public init(
         email: String = "",
         message: String = "",
         contactEmail: String = "gsm-chatbot@gsm.hs.kr",
+        isSending: Bool = false,
+        errorMessage: String? = nil,
         onBack: @escaping () -> Void = {},
         onDone: @escaping () -> Void = {},
         onSend: @escaping (String, String) -> Void = { _, _ in },
@@ -23,6 +27,8 @@ public struct ContactView: View {
         _email = State(initialValue: email)
         _message = State(initialValue: message)
         self.contactEmail = contactEmail
+        self.isSending = isSending
+        self.errorMessage = errorMessage
         self.onBack = onBack
         self.onDone = onDone
         self.onSend = onSend
@@ -100,10 +106,21 @@ public struct ContactView: View {
                 messageEditor
                     .padding(.top, 16)
 
-                HopesButton("문의 보내기", size: .large) {
+                HopesButton(
+                    isSending ? "전송 중..." : "문의 보내기",
+                    size: .large,
+                    isEnabled: !message.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
+                ) {
                     onSend(email, message)
                 }
                 .padding(.top, 30)
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(Color.hopesDanger)
+                        .padding(.top, 10)
+                }
             }
             .padding(.top, 16)
         }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -39,6 +39,9 @@ public struct LoginFlowView: View {
     @State private var customPrompt = ""
     @State private var isSavingSettings = false
     @State private var settingsErrorMessage: String?
+    @State private var isSendingInquiry = false
+    @State private var inquiryErrorMessage: String?
+    @State private var isLoggingOut = false
     @State private var conversations: [ConversationHistoryView.Conversation] = []
     @State private var isLoadingConversations = false
     @State private var conversationErrorMessage: String?
@@ -245,6 +248,8 @@ public struct LoginFlowView: View {
 
             case .settings:
                 SettingsView(
+                    isLoggingOut: isLoggingOut,
+                    errorMessage: settingsErrorMessage,
                     onBackToChat: {
                         transition(to: .chatHome)
                     },
@@ -258,7 +263,7 @@ public struct LoginFlowView: View {
                         transition(to: .contact)
                     },
                     onLogout: {
-                        transition(to: .login)
+                        logout()
                     },
                     onSelectTab: navigateFromTab
                 )
@@ -303,14 +308,17 @@ public struct LoginFlowView: View {
 
             case .contact:
                 ContactView(
+                    email: profileEmail,
+                    isSending: isSendingInquiry,
+                    errorMessage: inquiryErrorMessage,
                     onBack: {
                         transition(to: .settings)
                     },
                     onDone: {
                         transition(to: .settings)
                     },
-                    onSend: { _, _ in
-                        transition(to: .settings)
+                    onSend: { _, content in
+                        submitInquiry(content: content)
                     },
                     onSelectTab: navigateFromTab
                 )
@@ -433,6 +441,48 @@ public struct LoginFlowView: View {
         profileIntroduction = profile.profileInfo
         profileEmail = profile.email
         profileMajor = profile.major ?? "미설정"
+    }
+
+    private func submitInquiry(content: String) {
+        guard !isSendingInquiry else { return }
+        isSendingInquiry = true
+        inquiryErrorMessage = nil
+        Task {
+            do {
+                try await HopesAPIClient.shared.submitInquiry(content: content)
+                await MainActor.run {
+                    isSendingInquiry = false
+                    transition(to: .settings)
+                }
+            } catch {
+                await MainActor.run {
+                    isSendingInquiry = false
+                    inquiryErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func logout() {
+        guard !isLoggingOut else { return }
+        isLoggingOut = true
+        settingsErrorMessage = nil
+        Task {
+            do {
+                try await HopesAPIClient.shared.logout()
+                await MainActor.run {
+                    isLoggingOut = false
+                    activeChat = nil
+                    conversations = []
+                    transition(to: .login)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoggingOut = false
+                    settingsErrorMessage = error.localizedDescription
+                }
+            }
+        }
     }
 
     private func loadConversations(searchKeyword: String? = nil) {

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -10,9 +10,13 @@ public struct SettingsView: View {
     private let onOpenContact: () -> Void
     private let onLogout: () -> Void
     private let onSelectTab: (HopesTab) -> Void
+    private let isLoggingOut: Bool
+    private let errorMessage: String?
 
     public init(
         contactEmail: String = "gsm-chatbot@gsm.hs.kr",
+        isLoggingOut: Bool = false,
+        errorMessage: String? = nil,
         onBackToChat: @escaping () -> Void = {},
         onOpenGeneral: @escaping () -> Void = {},
         onOpenPersonalSettings: @escaping () -> Void = {},
@@ -21,6 +25,8 @@ public struct SettingsView: View {
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.contactEmail = contactEmail
+        self.isLoggingOut = isLoggingOut
+        self.errorMessage = errorMessage
         self.onBackToChat = onBackToChat
         self.onOpenGeneral = onOpenGeneral
         self.onOpenPersonalSettings = onOpenPersonalSettings
@@ -58,14 +64,23 @@ public struct SettingsView: View {
             .padding(.top, 217)
 
             HopesButton(
-                "로그아웃",
+                isLoggingOut ? "로그아웃 중..." : "로그아웃",
                 variant: .danger,
                 width: .fixed(330),
+                isEnabled: !isLoggingOut,
                 action: onLogout
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 29)
             .padding(.top, 307)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesDanger)
+                    .padding(.horizontal, 30)
+                    .padding(.top, 365)
+            }
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)


### PR DESCRIPTION
## 변경 사항
- 문의 내용을 `/api/setting/inquiry`로 전송하고 서버 성공 후 화면을 전환합니다.
- 로그아웃을 `/api/logout`과 연결하고 서버 성공 후에만 Keychain 토큰을 삭제합니다.
- 요청 중 중복 실행을 막고 서버 오류 메시지를 화면에 표시합니다.

## 검증
- `swift test` (29 tests)
- iPhone 17 Pro 시뮬레이터 대상 앱 빌드 성공
- 실서버 인증 누락 요청 401 확인

Closes #84