### PR TITLE
feat: [#86] 실서버 비밀번호 재설정 연동

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -41,6 +41,16 @@ public struct EmailVerificationConfirmRequest: Encodable, Sendable {
     public let code: String
 }
 
+public struct PasswordResetRequest: Encodable, Sendable {
+    public let email: String
+}
+
+public struct PasswordResetConfirmRequest: Encodable, Sendable {
+    public let email: String
+    public let code: String
+    public let newPassword: String
+}
+
 public struct SignupRequest: Encodable, Sendable {
     public let email: String
     public let username: String

--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -65,6 +65,26 @@ public actor HopesAPIClient {
     }
 
     @discardableResult
+    public func requestPasswordReset(email: String) async throws -> MessageEnvelope {
+        try await request(
+            path: "/api/password/request",
+            method: "POST",
+            body: PasswordResetRequest(email: email),
+            requiresAuthentication: false
+        )
+    }
+
+    @discardableResult
+    public func resetPassword(email: String, code: String, newPassword: String) async throws -> MessageEnvelope {
+        try await request(
+            path: "/api/password/reset",
+            method: "POST",
+            body: PasswordResetConfirmRequest(email: email, code: code, newPassword: newPassword),
+            requiresAuthentication: false
+        )
+    }
+
+    @discardableResult
     public func signUp(_ signupRequest: SignupRequest) async throws -> TokenResponse {
         let response: TokenResponse = try await request(
             path: "/api/signup",

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -4,6 +4,7 @@ public struct LoginFlowView: View {
     private enum Screen {
         case guide
         case login
+        case passwordReset
         case signUp
         case onboarding
         case chatHome
@@ -23,6 +24,11 @@ public struct LoginFlowView: View {
     @State private var password = ""
     @State private var isLoggingIn = false
     @State private var loginErrorMessage: String?
+    @State private var passwordResetCode = ""
+    @State private var passwordResetNewPassword = ""
+    @State private var isPasswordResetCodeRequested = false
+    @State private var isResettingPassword = false
+    @State private var passwordResetErrorMessage: String?
     @State private var signUpEmail = ""
     @State private var name = ""
     @State private var major = ""
@@ -129,9 +135,26 @@ public struct LoginFlowView: View {
                     },
                     onSignUp: {
                         transition(to: .signUp)
+                    },
+                    onForgotPassword: {
+                        transition(to: .passwordReset)
                     }
                 )
                 .transition(.move(edge: .bottom))
+
+            case .passwordReset:
+                PasswordResetView(
+                    email: $email,
+                    code: $passwordResetCode,
+                    newPassword: $passwordResetNewPassword,
+                    codeRequested: isPasswordResetCodeRequested,
+                    isLoading: isResettingPassword,
+                    errorMessage: passwordResetErrorMessage,
+                    onBack: { transition(to: .login) },
+                    onRequestCode: requestPasswordResetCode,
+                    onReset: resetPassword
+                )
+                .transition(.move(edge: .trailing))
 
             case .signUp:
                 SignUpView(
@@ -357,6 +380,54 @@ public struct LoginFlowView: View {
         }
     }
 
+    private func requestPasswordResetCode() {
+        guard !isResettingPassword else { return }
+        isResettingPassword = true
+        passwordResetErrorMessage = nil
+        Task {
+            do {
+                try await HopesAPIClient.shared.requestPasswordReset(email: email.trimmingCharacters(in: .whitespacesAndNewlines))
+                await MainActor.run {
+                    isResettingPassword = false
+                    isPasswordResetCodeRequested = true
+                }
+            } catch {
+                await MainActor.run {
+                    isResettingPassword = false
+                    passwordResetErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func resetPassword() {
+        guard !isResettingPassword else { return }
+        isResettingPassword = true
+        passwordResetErrorMessage = nil
+        Task {
+            do {
+                try await HopesAPIClient.shared.resetPassword(
+                    email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+                    code: passwordResetCode,
+                    newPassword: passwordResetNewPassword
+                )
+                await MainActor.run {
+                    isResettingPassword = false
+                    isPasswordResetCodeRequested = false
+                    passwordResetCode = ""
+                    passwordResetNewPassword = ""
+                    password = ""
+                    transition(to: .login)
+                }
+            } catch {
+                await MainActor.run {
+                    isResettingPassword = false
+                    passwordResetErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
     private func loadProfile() {
         guard !isLoadingProfile else { return }
         isLoadingProfile = true
@@ -449,7 +520,7 @@ public struct LoginFlowView: View {
         inquiryErrorMessage = nil
         Task {
             do {
-                try await HopesAPIClient.shared.submitInquiry(content: content)
+                _ = try await HopesAPIClient.shared.submitInquiry(content: content)
                 await MainActor.run {
                     isSendingInquiry = false
                     transition(to: .settings)
@@ -469,7 +540,7 @@ public struct LoginFlowView: View {
         settingsErrorMessage = nil
         Task {
             do {
-                try await HopesAPIClient.shared.logout()
+                _ = try await HopesAPIClient.shared.logout()
                 await MainActor.run {
                     isLoggingOut = false
                     activeChat = nil

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -6,6 +6,7 @@ public struct LoginView: View {
 
     private let onLogin: () -> Void
     private let onSignUp: () -> Void
+    private let onForgotPassword: () -> Void
     private let isLoading: Bool
     private let errorMessage: String?
 
@@ -15,7 +16,8 @@ public struct LoginView: View {
         isLoading: Bool = false,
         errorMessage: String? = nil,
         onLogin: @escaping () -> Void = {},
-        onSignUp: @escaping () -> Void = {}
+        onSignUp: @escaping () -> Void = {},
+        onForgotPassword: @escaping () -> Void = {}
     ) {
         _email = email
         _password = password
@@ -23,6 +25,7 @@ public struct LoginView: View {
         self.errorMessage = errorMessage
         self.onLogin = onLogin
         self.onSignUp = onSignUp
+        self.onForgotPassword = onForgotPassword
     }
 
     public var body: some View {
@@ -130,6 +133,13 @@ public struct LoginView: View {
                     }
                     .padding(.top, 9)
                     .accessibilityLabel("비밀번호")
+
+                Button("비밀번호를 잊으셨나요?", action: onForgotPassword)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.hopesBrandPrimary)
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .padding(.top, 8)
             }
             .padding(.horizontal, 32)
             .padding(.top, 68)

--- a/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
+++ b/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+public struct PasswordResetView: View {
+    @Binding private var email: String
+    @Binding private var code: String
+    @Binding private var newPassword: String
+    private let codeRequested: Bool
+    private let isLoading: Bool
+    private let errorMessage: String?
+    private let onBack: () -> Void
+    private let onRequestCode: () -> Void
+    private let onReset: () -> Void
+
+    public init(
+        email: Binding<String>,
+        code: Binding<String>,
+        newPassword: Binding<String>,
+        codeRequested: Bool = false,
+        isLoading: Bool = false,
+        errorMessage: String? = nil,
+        onBack: @escaping () -> Void = {},
+        onRequestCode: @escaping () -> Void = {},
+        onReset: @escaping () -> Void = {}
+    ) {
+        _email = email
+        _code = code
+        _newPassword = newPassword
+        self.codeRequested = codeRequested
+        self.isLoading = isLoading
+        self.errorMessage = errorMessage
+        self.onBack = onBack
+        self.onRequestCode = onRequestCode
+        self.onReset = onReset
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(Color.hopesTextPrimary)
+            }
+            .buttonStyle(.plain)
+
+            Text("비밀번호 재설정")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(Color.hopesTextPrimary)
+                .padding(.top, 34)
+
+            Text("학교 이메일로 받은 인증번호를 입력해주세요.")
+                .font(.system(size: 14))
+                .foregroundStyle(Color.hopesTextSecondary)
+                .padding(.top, 6)
+
+            fieldTitle("이메일", top: 36)
+            TextField("학교 이메일", text: $email)
+                .textFieldStyle(HopesResetFieldStyle())
+                .disabled(codeRequested)
+
+            if codeRequested {
+                fieldTitle("인증번호", top: 18)
+                TextField("숫자 6자리", text: $code)
+                    .textFieldStyle(HopesResetFieldStyle())
+
+                fieldTitle("새 비밀번호", top: 18)
+                SecureField("영문+숫자 8~15자", text: $newPassword)
+                    .textFieldStyle(HopesResetFieldStyle())
+            }
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(Color.hopesDanger)
+                    .padding(.top, 12)
+            }
+
+            Spacer()
+
+            HopesButton(
+                isLoading ? "처리 중..." : codeRequested ? "비밀번호 변경" : "인증번호 받기",
+                isEnabled: canSubmit,
+                action: codeRequested ? onReset : onRequestCode
+            )
+        }
+        .padding(.horizontal, 28)
+        .padding(.top, 24)
+        .padding(.bottom, 34)
+        .background(Color.hopesBackground.ignoresSafeArea())
+    }
+
+    private var canSubmit: Bool {
+        guard !isLoading, !email.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return false }
+        return !codeRequested || (code.range(of: #"^\d{6}$"#, options: .regularExpression) != nil && PasswordPolicy.isValid(newPassword))
+    }
+
+    private func fieldTitle(_ title: String, top: CGFloat) -> some View {
+        Text(title)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Color.hopesTextPrimary)
+            .padding(.top, top)
+            .padding(.bottom, 8)
+    }
+}
+
+private struct HopesResetFieldStyle: TextFieldStyle {
+    func _body(configuration: TextField<Self._Label>) -> some View {
+        configuration
+            .font(.system(size: 15))
+            .padding(.horizontal, 16)
+            .frame(height: 48)
+            .background(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay {
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color.hopesBorder, lineWidth: 1)
+            }
+    }
+}

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -226,6 +226,12 @@ func loginViewsCanBeConstructed() {
     _ = LoginFlowView(isLoginInitiallyOpen: true)
     _ = LoginFlowView(isSignUpInitiallyOpen: true)
     _ = LoginFlowView(isOnboardingInitiallyOpen: true)
+    _ = PasswordResetView(
+        email: .constant("s26055@gsm.hs.kr"),
+        code: .constant("123456"),
+        newPassword: .constant("password1"),
+        codeRequested: true
+    )
 }
 
 @Test


### PR DESCRIPTION
## 변경 사항
- 로그인 화면에 비밀번호 재설정 진입점을 추가했습니다.
- 인증번호 발송을 `POST /api/password/request`에 연결했습니다.
- 이메일·6자리 코드·새 비밀번호를 `POST /api/password/reset`에 전송합니다.
- 서버와 동일한 영문+숫자 8~15자 정규식, 로딩 및 오류 상태를 적용했습니다.

## 검증
- `swift test` 29개 통과
- iPhone 17 Pro 시뮬레이터 앱 빌드 성공
- 실서버 두 엔드포인트 유효성 오류 400 응답 확인

Closes #86