### PR TITLE
feat: [#88] 인증 세션 복원 및 만료 처리

### DIFF
--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -32,6 +32,10 @@ public actor HopesAPIClient {
         self.tokenStore = tokenStore
     }
 
+    public func hasStoredAccessToken() async throws -> Bool {
+        try await tokenStore.token() != nil
+    }
+
     @discardableResult
     public func login(username: String, password: String) async throws -> TokenResponse {
         let response: TokenResponse = try await request(
@@ -284,6 +288,9 @@ public actor HopesAPIClient {
             let message = (try? decoder.decode(MessageEnvelope.self, from: data).message)
                 ?? "요청을 처리하지 못했습니다."
             if httpResponse.statusCode == 401 {
+                if requiresAuthentication {
+                    try? await tokenStore.clear()
+                }
                 throw HopesAPIError.unauthorized(message)
             }
             throw HopesAPIError.server(statusCode: httpResponse.statusCode, message: message)

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -60,6 +60,7 @@ public struct LoginFlowView: View {
     private let onLogin: () -> Void
     private let onSignUp: (SignUpFormData) -> Void
     private let onStartChat: () -> Void
+    private let restoresSessionOnLaunch: Bool
 
     public init(
         isLoginInitiallyOpen: Bool = false,
@@ -110,6 +111,7 @@ public struct LoginFlowView: View {
         }
 
         _screen = State(initialValue: initialScreen)
+        restoresSessionOnLaunch = initialScreen == .guide
         self.onLogin = onLogin
         self.onSignUp = onSignUp
         self.onStartChat = onStartChat
@@ -361,7 +363,9 @@ public struct LoginFlowView: View {
             }
         }
         .task {
-            if screen == .chatHome || screen == .conversationHistory {
+            if restoresSessionOnLaunch && screen == .guide {
+                restoreSession()
+            } else if screen == .chatHome || screen == .conversationHistory {
                 loadConversations()
             }
         }
@@ -378,6 +382,44 @@ public struct LoginFlowView: View {
         } else if screen == .settings || screen == .personalSettings {
             loadSettings()
         }
+    }
+
+    private func restoreSession() {
+        Task {
+            do {
+                guard try await HopesAPIClient.shared.hasStoredAccessToken() else { return }
+                let response = try await HopesAPIClient.shared.main()
+                let mappedConversations = response.chatList.map { summary in
+                    ConversationHistoryView.Conversation(
+                        id: summary.id,
+                        title: summary.title,
+                        period: conversationPeriod(for: summary.updatedAt)
+                    )
+                }
+                await MainActor.run {
+                    conversations = mappedConversations
+                    withAnimation(.spring(response: 0.42, dampingFraction: 0.88)) {
+                        screen = .chatHome
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    handleAuthenticationFailure(error)
+                }
+            }
+        }
+    }
+
+    private func handleAuthenticationFailure(_ error: Error) {
+        guard let apiError = error as? HopesAPIError,
+              case .unauthorized = apiError
+        else { return }
+        activeChat = nil
+        selectedConversationID = nil
+        conversations = []
+        password = ""
+        loginErrorMessage = "로그인이 만료되었습니다. 다시 로그인해주세요."
+        transition(to: .login)
     }
 
     private func requestPasswordResetCode() {
@@ -441,6 +483,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isLoadingProfile = false
                     profileErrorMessage = error.localizedDescription
                 }
@@ -465,6 +508,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isSavingProfile = false
                     profileErrorMessage = error.localizedDescription
                 }
@@ -482,7 +526,10 @@ public struct LoginFlowView: View {
                     settingsErrorMessage = nil
                 }
             } catch {
-                await MainActor.run { settingsErrorMessage = error.localizedDescription }
+                await MainActor.run {
+                    handleAuthenticationFailure(error)
+                    settingsErrorMessage = error.localizedDescription
+                }
             }
         }
     }
@@ -500,6 +547,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isSavingSettings = false
                     settingsErrorMessage = error.localizedDescription
                 }
@@ -527,6 +575,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isSendingInquiry = false
                     inquiryErrorMessage = error.localizedDescription
                 }
@@ -549,6 +598,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isLoggingOut = false
                     settingsErrorMessage = error.localizedDescription
                 }
@@ -576,6 +626,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isLoadingConversations = false
                     conversationErrorMessage = error.localizedDescription
                 }
@@ -603,6 +654,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isLoadingChat = false
                     chatErrorMessage = error.localizedDescription
                 }
@@ -624,6 +676,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isLoadingChat = false
                     chatErrorMessage = error.localizedDescription
                 }
@@ -651,6 +704,7 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
+                    handleAuthenticationFailure(error)
                     isSendingMessage = false
                     chatErrorMessage = error.localizedDescription
                 }


### PR DESCRIPTION
## 변경 사항
- 앱 실행 시 Keychain 토큰을 확인하고 `/api/main` 서버 검증 성공 후 홈을 복원합니다.
- 인증 요청에서 401을 받으면 저장 토큰을 즉시 삭제합니다.
- 프로필·설정·문의·대화 등 모든 인증 요청 실패를 로그인 만료 흐름에 연결했습니다.

## 검증
- `swift test` 29개 통과
- iPhone 17 Pro 시뮬레이터 앱 빌드 성공
- 실서버 인증 누락 `/api/main` 401 계약 확인

Closes #88