### PR TITLE
fix: [#90] 계정 정보 실서버 데이터 적용

### DIFF
--- a/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
+++ b/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
@@ -9,8 +9,6 @@ public struct AccountInfoView: View {
     private let isSchoolVerified: Bool
     private let onBack: () -> Void
     private let onDone: () -> Void
-    private let onExportData: () -> Void
-    private let onDeleteAccount: () -> Void
     private let onSelectTab: (HopesTab) -> Void
 
     public init(
@@ -20,8 +18,6 @@ public struct AccountInfoView: View {
         isSchoolVerified: Bool = true,
         onBack: @escaping () -> Void = {},
         onDone: @escaping () -> Void = {},
-        onExportData: @escaping () -> Void = {},
-        onDeleteAccount: @escaping () -> Void = {},
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.email = email
@@ -30,8 +26,6 @@ public struct AccountInfoView: View {
         self.isSchoolVerified = isSchoolVerified
         self.onBack = onBack
         self.onDone = onDone
-        self.onExportData = onExportData
-        self.onDeleteAccount = onDeleteAccount
         self.onSelectTab = onSelectTab
     }
 
@@ -46,10 +40,6 @@ public struct AccountInfoView: View {
             accountCard
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
                 .padding(.top, 156)
-
-            actionButtons
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 500)
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -122,25 +112,6 @@ public struct AccountInfoView: View {
         .frame(height: 284)
     }
 
-    private var actionButtons: some View {
-        HStack(spacing: 14) {
-            HopesButton(
-                "데이터 내보내기",
-                variant: .secondary,
-                size: .regular,
-                width: .fixed(170),
-                action: onExportData
-            )
-
-            HopesButton(
-                "계정 삭제",
-                variant: .danger,
-                size: .regular,
-                width: .fixed(170),
-                action: onDeleteAccount
-            )
-        }
-    }
 }
 
 #Preview("계정 정보") {

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -39,6 +39,7 @@ public struct LoginFlowView: View {
     @State private var profileIntroduction = ""
     @State private var profileEmail = ""
     @State private var profileMajor = ""
+    @State private var profileCohort = ""
     @State private var isLoadingProfile = false
     @State private var isSavingProfile = false
     @State private var profileErrorMessage: String?
@@ -351,6 +352,9 @@ public struct LoginFlowView: View {
 
             case .accountInfo:
                 AccountInfoView(
+                    email: profileEmail,
+                    major: profileMajor,
+                    cohort: profileCohort,
                     onBack: {
                         transition(to: .myPage)
                     },
@@ -560,6 +564,7 @@ public struct LoginFlowView: View {
         profileIntroduction = profile.profileInfo
         profileEmail = profile.email
         profileMajor = profile.major ?? "미설정"
+        profileCohort = profile.cohort.map { "\($0)기" } ?? "미설정"
     }
 
     private func submitInquiry(content: String) {


### PR DESCRIPTION
## 변경 사항
- 계정 정보에 `/api/mypage` 응답의 실제 이메일·전공·기수를 표시합니다.
- 백엔드 계약이 없어 동작하지 않던 데이터 내보내기·계정 삭제 버튼을 제거했습니다.

## 검증
- `swift test` 29개 통과
- iPhone 17 Pro 시뮬레이터 앱 빌드 성공

Closes #90