### PR TITLE
feat: [#92] 전체 대화 삭제 실서버 연동

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -327,6 +327,7 @@ public struct LoginFlowView: View {
                     onSavePrompt: { prompt in
                         saveSettings(prompt: prompt)
                     },
+                    onDeleteAllConversations: deleteAllConversations,
                     onSelectTab: navigateFromTab
                 )
                     .id(customPrompt)
@@ -547,6 +548,33 @@ public struct LoginFlowView: View {
                 let settings = try await HopesAPIClient.shared.updateSettings(customPrompt: prompt)
                 await MainActor.run {
                     customPrompt = settings.customPrompt
+                    isSavingSettings = false
+                }
+            } catch {
+                await MainActor.run {
+                    handleAuthenticationFailure(error)
+                    isSavingSettings = false
+                    settingsErrorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func deleteAllConversations() {
+        guard !isSavingSettings else { return }
+        isSavingSettings = true
+        settingsErrorMessage = nil
+        Task {
+            do {
+                let settings = try await HopesAPIClient.shared.updateSettings(
+                    customPrompt: nil,
+                    deleteAllChats: true
+                )
+                await MainActor.run {
+                    customPrompt = settings.customPrompt
+                    conversations = []
+                    activeChat = nil
+                    selectedConversationID = nil
                     isSavingSettings = false
                 }
             } catch {

--- a/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct PersonalSettingsView: View {
     @State private var selectedTab: HopesTab = .settings
     @State private var systemPrompt: String
+    @State private var showsDeleteConfirmation = false
 
     private let onBack: () -> Void
     private let onDone: () -> Void
@@ -47,10 +48,30 @@ public struct PersonalSettingsView: View {
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
                 .padding(.top, 158)
 
+            HopesButton(
+                "전체 대화 삭제",
+                variant: .danger,
+                isEnabled: !isSaving
+            ) {
+                showsDeleteConfirmation = true
+            }
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.top, 590)
+
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
         }
         .ignoresSafeArea()
+        .confirmationDialog(
+            "모든 대화를 삭제할까요?",
+            isPresented: $showsDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("전체 대화 삭제", role: .destructive, action: onDeleteAllConversations)
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("서버에 저장된 모든 대화가 삭제되며 되돌릴 수 없습니다.")
+        }
     }
 
     private var header: some View {


### PR DESCRIPTION
## 변경 사항
- 개인 설정에 전체 대화 삭제 버튼과 파괴적 작업 확인창을 추가했습니다.
- 확인 시 `PATCH /api/setting`에 `deleteAllChats: true`를 전송합니다.
- 서버 성공 후에만 로컬 대화 상태를 비우며 실패 시 서버 오류를 표시합니다.

## 검증
- `swift test` 29개 통과
- iPhone 17 Pro 시뮬레이터 앱 빌드 성공

Closes #92