### PR TITLE
fix: [#96] 인증 저장소 오류 메시지 분리

### DIFF
--- a/Sources/HopesDesignSystem/Networking/APIModels.swift
+++ b/Sources/HopesDesignSystem/Networking/APIModels.swift
@@ -150,6 +150,7 @@ public enum HopesAPIError: LocalizedError, Sendable, Equatable {
     case unauthorized(String)
     case server(statusCode: Int, message: String)
     case transport(String)
+    case credentialStorage(String)
     case decoding
 
     public var errorDescription: String? {
@@ -160,6 +161,8 @@ public enum HopesAPIError: LocalizedError, Sendable, Equatable {
             message
         case .transport:
             "서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
+        case .credentialStorage:
+            "로그인 정보를 안전하게 저장하지 못했습니다. 앱을 다시 실행한 후 시도해주세요."
         case .decoding:
             "서버 응답을 처리하지 못했습니다."
         }

--- a/Sources/HopesDesignSystem/Networking/AccessTokenStore.swift
+++ b/Sources/HopesDesignSystem/Networking/AccessTokenStore.swift
@@ -23,7 +23,7 @@ public actor AccessTokenStore {
 
         let status = SecItemAdd(attributes as CFDictionary, nil)
         guard status == errSecSuccess else {
-            throw HopesAPIError.transport("Keychain status: \(status)")
+            throw HopesAPIError.credentialStorage("Keychain save status: \(status)")
         }
     }
 
@@ -43,7 +43,7 @@ public actor AccessTokenStore {
               let data = result as? Data,
               let token = String(data: data, encoding: .utf8)
         else {
-            throw HopesAPIError.transport("Keychain status: \(status)")
+            throw HopesAPIError.credentialStorage("Keychain read status: \(status)")
         }
         return token
     }
@@ -56,7 +56,7 @@ public actor AccessTokenStore {
         ]
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
-            throw HopesAPIError.transport("Keychain status: \(status)")
+            throw HopesAPIError.credentialStorage("Keychain delete status: \(status)")
         }
     }
 }

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -15,6 +15,14 @@ func serverErrorsExposeUserFacingMessages() {
     let error = HopesAPIError.unauthorized("등록된 회원을 찾을 수 없습니다.")
 
     #expect(error.errorDescription == "등록된 회원을 찾을 수 없습니다.")
+    #expect(
+        HopesAPIError.transport("offline").errorDescription
+            == "서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."
+    )
+    #expect(
+        HopesAPIError.credentialStorage("Keychain status: -34018").errorDescription
+            == "로그인 정보를 안전하게 저장하지 못했습니다. 앱을 다시 실행한 후 시도해주세요."
+    )
 }
 
 @Test


### PR DESCRIPTION
## 변경 사항
- Keychain 저장·조회·삭제 오류를 네트워크 오류와 분리했습니다.
- 인증 저장소 실패 시 로그인 정보 저장 오류를 표시합니다.
- 실제 URLSession 실패에만 서버 연결 오류를 표시합니다.

## 검증
- 오류 메시지 구분 테스트 포함 `swift test` 29개 통과
- iPhone 17 Pro 시뮬레이터 앱 빌드 성공

Closes #96