### PR TITLE
fix: [#100] 회원가입 입력 카드 스크롤 구조 조정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -71,10 +71,9 @@ public struct SignUpView: View {
             Color.hopesBackground.ignoresSafeArea()
             header
 
-            signUpCard
+            signUpPanel
                 .padding(.horizontal, 24)
                 .padding(.top, 217)
-                .padding(.bottom, 92)
 
             HopesTabBar(selection: $selectedTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -86,6 +85,15 @@ public struct SignUpView: View {
             statusMessage = nil
             errorMessage = nil
         }
+    }
+
+    private var signUpPanel: some View {
+        VStack(spacing: 14) {
+            signUpCard
+            signUpButton
+            loginLink
+        }
+        .padding(.bottom, 96)
     }
 
     private var header: some View {
@@ -107,38 +115,34 @@ public struct SignUpView: View {
 
     private var signUpCard: some View {
         ScrollView(showsIndicators: true) {
-            VStack(spacing: 20) {
-                VStack(spacing: 0) {
-                    signUpField("학교 이메일", text: $email, placeholder: "s26055@gsm.hs.kr", kind: .email)
-                    verificationField
-                    signUpField("이름", text: $name, placeholder: "임서하")
-                    signUpField(
-                        "비밀번호",
-                        text: $password,
-                        placeholder: "영문·숫자 포함 8~15자",
-                        kind: .password,
-                        isPasswordVisible: $isPasswordVisible
-                    )
-                    signUpField(
-                        "비밀번호 확인",
-                        text: $passwordConfirm,
-                        placeholder: "비밀번호 재입력",
-                        kind: .password,
-                        isPasswordVisible: $isPasswordConfirmVisible
-                    )
-                    signUpField("과", text: $major, placeholder: "AI", kind: .major)
-                    signUpField("기수", text: $cohort, placeholder: "10기", kind: .cohort)
-                }
-
-                signUpButton
-                loginLink
+            VStack(spacing: 0) {
+                signUpField("학교 이메일", text: $email, placeholder: "s26055@gsm.hs.kr", kind: .email)
+                verificationField
+                signUpField("이름", text: $name, placeholder: "임서하")
+                signUpField(
+                    "비밀번호",
+                    text: $password,
+                    placeholder: "영문·숫자 포함 8~15자",
+                    kind: .password,
+                    isPasswordVisible: $isPasswordVisible
+                )
+                signUpField(
+                    "비밀번호 확인",
+                    text: $passwordConfirm,
+                    placeholder: "비밀번호 재입력",
+                    kind: .password,
+                    isPasswordVisible: $isPasswordConfirmVisible
+                )
+                signUpField("과", text: $major, placeholder: "AI", kind: .major)
+                signUpField("기수", text: $cohort, placeholder: "10기", kind: .cohort)
             }
             .padding(.horizontal, 17)
             .padding(.top, 30)
             .padding(.bottom, 28)
         }
         .scrollBounceBehavior(.basedOnSize)
-        .frame(maxWidth: 354, maxHeight: .infinity)
+        .frame(maxWidth: 354)
+        .frame(height: 450)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
         .overlay {


### PR DESCRIPTION
## 변경 사항
- 입력 필드만 흰색 카드 내부에서 스크롤되도록 변경했습니다.
- 회원가입 버튼과 로그인 링크를 카드 아래 고정 영역으로 분리했습니다.
- 비밀번호 표시 전환과 기존 유효성 검증은 유지했습니다.

## 검증
- `swift test` 29개 통과
- iPhone 17 Pro 정상 서명 빌드 및 실행 성공

Closes #100