### PR TITLE
fix: 설정 탭을 마이페이지로 변경

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -15,7 +15,7 @@ public enum HopesTab: String, CaseIterable, Sendable {
         case .history:
             "기록"
         case .settings:
-            "설정"
+            "마이페이지"
         }
     }
 
@@ -28,7 +28,7 @@ public enum HopesTab: String, CaseIterable, Sendable {
         case .history:
             "clock.arrow.circlepath"
         case .settings:
-            "gearshape"
+            "person"
         }
     }
 
@@ -41,7 +41,7 @@ public enum HopesTab: String, CaseIterable, Sendable {
         case .history:
             "clock.arrow.circlepath"
         case .settings:
-            "gearshape.fill"
+            "person.fill"
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
- 하단 설정 탭 문구를 마이페이지로 변경
- 탭 아이콘을 person / person.fill로 변경
- 기존 마이페이지 이동 연결 유지

## 검증
- swift test (29개 통과)
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #106