### PR TITLE
fix: 마이페이지 뒤로가기 내비게이션 적용

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -259,7 +259,10 @@ public struct LoginFlowView: View {
                     isLoading: isLoadingProfile,
                     isSaving: isSavingProfile,
                     errorMessage: profileErrorMessage,
-                    onBackToChat: {
+                    onBack: {
+                        transition(to: .chatHome)
+                    },
+                    onOpenSettings: {
                         transition(to: .settings)
                     },
                     onSave: { profile in

--- a/Sources/HopesDesignSystem/Screens/MyPageView.swift
+++ b/Sources/HopesDesignSystem/Screens/MyPageView.swift
@@ -22,7 +22,8 @@ public struct MyPageView: View {
     private let isLoading: Bool
     private let isSaving: Bool
     private let errorMessage: String?
-    private let onBackToChat: () -> Void
+    private let onBack: () -> Void
+    private let onOpenSettings: () -> Void
     private let onSave: (Profile) -> Void
     private let onOpenAccountInfo: () -> Void
     private let onSelectTab: (HopesTab) -> Void
@@ -35,7 +36,8 @@ public struct MyPageView: View {
         isLoading: Bool = false,
         isSaving: Bool = false,
         errorMessage: String? = nil,
-        onBackToChat: @escaping () -> Void = {},
+        onBack: @escaping () -> Void = {},
+        onOpenSettings: @escaping () -> Void = {},
         onSave: @escaping (Profile) -> Void = { _ in },
         onOpenAccountInfo: @escaping () -> Void = {},
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
@@ -53,7 +55,8 @@ public struct MyPageView: View {
         self.isLoading = isLoading
         self.isSaving = isSaving
         self.errorMessage = errorMessage
-        self.onBackToChat = onBackToChat
+        self.onBack = onBack
+        self.onOpenSettings = onOpenSettings
         self.onSave = onSave
         self.onOpenAccountInfo = onOpenAccountInfo
         self.onSelectTab = onSelectTab
@@ -116,7 +119,20 @@ public struct MyPageView: View {
 
     private var header: some View {
         HStack {
-            HopesLogo()
+            Button(action: onBack) {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Color.hopesBrandPrimary)
+                    .frame(width: 38, height: 38)
+                    .background(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 13))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 13)
+                            .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("이전 화면으로 돌아가기")
 
             Spacer()
 
@@ -125,7 +141,7 @@ public struct MyPageView: View {
                 variant: .secondary,
                 size: .small,
                 width: .fixed(54),
-                action: onBackToChat
+                action: onOpenSettings
             )
         }
     }

--- a/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
+++ b/Tests/HopesDesignSystemTests/HopesDesignSystemTests.swift
@@ -327,7 +327,8 @@ func myPageViewCanBeConstructed() {
     _ = MyPageView(
         name: .constant("임서하"),
         introduction: .constant("프론트엔드에 관심이 많아요."),
-        onBackToChat: {},
+        onBack: {},
+        onOpenSettings: {},
         onSave: { _ in }
     )
     _ = LoginFlowView(isMyPageInitiallyOpen: true)


### PR DESCRIPTION
## 변경 사항
- 마이페이지 상단에 뒤로가기 버튼 적용
- 뒤로가기와 설정 페이지 이동 콜백 분리
- 뒤로가기는 채팅 홈, 설정 버튼은 설정 페이지로 연결

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #108