### PR TITLE
fix: 회원가입 입력 카드 피그마 구조로 변경

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -114,10 +114,9 @@ public struct SignUpView: View {
     }
 
     private var signUpCard: some View {
-        ScrollView(showsIndicators: true) {
+        ScrollView(showsIndicators: false) {
             VStack(spacing: 0) {
                 signUpField("학교 이메일", text: $email, placeholder: "s26055@gsm.hs.kr", kind: .email)
-                verificationField
                 signUpField("이름", text: $name, placeholder: "임서하")
                 signUpField("과", text: $major, placeholder: "학과 선택", kind: .major)
                 signUpField("기수", text: $cohort, placeholder: "기수 선택", kind: .cohort)
@@ -135,6 +134,7 @@ public struct SignUpView: View {
                     kind: .password,
                     isPasswordVisible: $isPasswordConfirmVisible
                 )
+                verificationField
             }
             .padding(.horizontal, 16)
             .padding(.top, 24)


### PR DESCRIPTION
## 변경 사항
- 회원가입 카드 첫 화면을 학교 이메일, 이름, 과, 기수, 비밀번호 순서로 변경
- 스크롤 인디케이터 제거
- 비밀번호 확인과 인증번호는 하단 스크롤 영역에 유지해 서버 필수 인증 흐름 보존

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공
- 회원가입 화면 재실행 확인

Closes #110