### PR TITLE
fix: 회원가입 인증번호 영역을 카드 내부에 배치

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -117,6 +117,7 @@ public struct SignUpView: View {
         ScrollView(showsIndicators: false) {
             VStack(spacing: 0) {
                 signUpField("학교 이메일", text: $email, placeholder: "s26055@gsm.hs.kr", kind: .email)
+                verificationField
                 signUpField("이름", text: $name, placeholder: "임서하")
                 signUpField("과", text: $major, placeholder: "학과 선택", kind: .major)
                 signUpField("기수", text: $cohort, placeholder: "기수 선택", kind: .cohort)
@@ -134,7 +135,6 @@ public struct SignUpView: View {
                     kind: .password,
                     isPasswordVisible: $isPasswordConfirmVisible
                 )
-                verificationField
             }
             .padding(.horizontal, 16)
             .padding(.top, 24)


### PR DESCRIPTION
## 변경 사항
- 학교 이메일 바로 아래에 인증번호 입력과 번호 발송 버튼 배치
- 이름, 과, 기수가 같은 카드 안에서 이어지도록 순서 수정
- 서버 이메일 인증 흐름 유지

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공
- 회원가입 화면 재실행 확인

Closes #112