### PR TITLE
fix: 로그인 비밀번호 표시 버튼 동작 구현

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 public struct LoginView: View {
+    @State private var isPasswordVisible = false
     @Binding private var email: String
     @Binding private var password: String
 
@@ -112,7 +113,13 @@ public struct LoginView: View {
                     .foregroundStyle(Color.hopesTextPrimary)
                     .padding(.top, 15)
 
-                SecureField("비밀번호", text: $password)
+                Group {
+                    if isPasswordVisible {
+                        TextField("비밀번호", text: $password)
+                    } else {
+                        SecureField("비밀번호", text: $password)
+                    }
+                }
                     .hopesPasswordInputTraits()
                     .font(.system(size: 15))
                     .foregroundStyle(Color.hopesTextPrimary)
@@ -126,10 +133,17 @@ public struct LoginView: View {
                             .stroke(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255), lineWidth: 1)
                     }
                     .overlay(alignment: .trailing) {
-                        Image(systemName: "eye.slash")
-                            .font(.system(size: 14))
-                            .foregroundStyle(Color.hopesTextSecondary)
-                            .padding(.trailing, 10)
+                        Button {
+                            isPasswordVisible.toggle()
+                        } label: {
+                            Image(systemName: isPasswordVisible ? "eye" : "eye.slash")
+                                .font(.system(size: 14))
+                                .foregroundStyle(Color.hopesTextSecondary)
+                                .frame(width: 42, height: 40)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel(isPasswordVisible ? "비밀번호 숨기기" : "비밀번호 보기")
                     }
                     .padding(.top, 9)
                     .accessibilityLabel("비밀번호")


### PR DESCRIPTION
## 변경 사항
- 로그인 눈 아이콘을 실제 버튼으로 변경
- 비밀번호 표시/숨김 상태 전환 구현
- 42x40 탭 영역과 접근성 라벨 적용

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #114