### PR TITLE
fix: 설정 화면 다크 모드 항목 제거

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 
 public struct SettingsView: View {
     @State private var selectedTab: HopesTab = .settings
-    @State private var isDarkMode = false
 
     private let contactEmail: String
     private let onBackToChat: () -> Void
@@ -64,12 +63,6 @@ public struct SettingsView: View {
             .padding(.leading, 37)
             .padding(.top, 217)
 
-            darkModeRow
-                .frame(width: 314)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.leading, 39)
-                .padding(.top, 307)
-
             HopesButton(
                 isLoggingOut ? "로그아웃 중..." : "로그아웃",
                 variant: .danger,
@@ -79,14 +72,14 @@ public struct SettingsView: View {
             )
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 29)
-            .padding(.top, 397)
+            .padding(.top, 307)
 
             if let errorMessage {
                 Text(errorMessage)
                     .font(.footnote)
                     .foregroundStyle(Color.hopesDanger)
                     .padding(.horizontal, 30)
-                    .padding(.top, 455)
+                    .padding(.top, 365)
             }
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
@@ -125,33 +118,6 @@ public struct SettingsView: View {
         }
     }
 
-    private var darkModeRow: some View {
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("다크 모드")
-                    .font(.body.weight(.semibold))
-                    .foregroundStyle(Color.hopesTextPrimary)
-
-                Text("시스템 설정에 맞춰 전환")
-                    .font(.footnote)
-                    .foregroundStyle(Color.hopesTextSecondary)
-            }
-
-            Spacer()
-
-            Toggle("다크 모드", isOn: $isDarkMode)
-                .labelsHidden()
-                .tint(Color.hopesBrandPrimary)
-        }
-        .padding(.horizontal, 20)
-        .frame(height: 64)
-        .background(.white)
-        .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
-        .overlay {
-            RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
-                .stroke(Color.hopesBorder, lineWidth: 1)
-        }
-    }
 }
 
 #Preview("설정") {


### PR DESCRIPTION
## 변경 사항
- 설정 화면 다크 모드 행 제거
- 로그아웃 버튼을 위로 이동해 빈 공간 정리
- 오류 메시지 위치 함께 조정

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공

Closes #118