### PR TITLE
fix: 회원가입 입력 카드를 고정 크기 내부 스크롤로 조정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -72,8 +72,8 @@ public struct SignUpView: View {
             header
 
             signUpPanel
-                .padding(.horizontal, 20)
-                .padding(.top, 217)
+                .padding(.horizontal, 24)
+                .padding(.top, 276)
 
             HopesTabBar(selection: $selectedTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
@@ -88,10 +88,12 @@ public struct SignUpView: View {
     }
 
     private var signUpPanel: some View {
-        VStack(spacing: 14) {
+        VStack(spacing: 0) {
             signUpCard
             signUpButton
+                .padding(.top, 42)
             loginLink
+                .padding(.top, 10)
         }
         .padding(.bottom, 96)
     }
@@ -141,8 +143,8 @@ public struct SignUpView: View {
             .padding(.bottom, 24)
         }
         .scrollBounceBehavior(.basedOnSize)
-        .frame(maxWidth: 362)
-        .frame(height: 450)
+        .frame(maxWidth: 354)
+        .frame(height: 386)
         .background(.white)
         .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
         .overlay {


### PR DESCRIPTION
## 변경 사항
- 입력 카드 크기를 피그마 기준 354x386으로 축소
- 카드 위치를 상단 276pt로 조정
- 비밀번호 이하 입력이 카드 밖으로 나오지 않고 내부 스크롤되도록 처리
- 회원가입 버튼과 로그인 링크를 카드 외부 고정 위치로 조정

## 검증
- swift test 29개 통과
- iPhone 17 Pro 시뮬레이터 빌드 성공
- 회원가입 화면 재실행 확인

Closes #120