### PR TITLE
chore:[#126] 앱 심사시 앱 아이콘 미적용 문제 해결

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -27,9 +27,17 @@ let project = Project(
                 ]
             ),
             sources: ["Sources/**"],
+            resources: [
+                "../Resources/**",
+            ],
             dependencies: [
                 .package(product: "HopesDesignSystem"),
-            ]
+            ],
+            settings: .settings(
+                base: [
+                    "ASSETCATALOG_COMPILER_APPICON_NAME": "AppIcon",
+                ]
+            )
         ),
     ]
 )


### PR DESCRIPTION
## 📌 변경사항
배포할때 앱 아이콘이 안뜨는 문제를 해결했습니다

## 📷 스크린샷



## 🔗 관련 이슈

close #126 

## 💬 참고사항
없음

