### PR TITLE
fix: [#139] 런치 및 공용 로고 표시 복구

### DIFF
--- a/App/Project.swift
+++ b/App/Project.swift
@@ -16,7 +16,7 @@ let project = Project(
                 with: [
                     "UILaunchScreen": [
                         "UIColorName": "HopesBrandPrimary",
-                        "UIImageName": "AppIcon",
+                        "UIImageName": "AppIcon60x60",
                     ],
                     "UIUserInterfaceStyle": "Light",
                     "NSAppTransportSecurity": [

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -15,7 +15,7 @@ let project = Project(
             infoPlist: .extendingDefault(
                 with: [
                     "UILaunchScreen": [
-                        "UIColorName": "HopesBackground",
+                        "UIColorName": "HopesBrandPrimary",
                         "UIImageName": "AppIcon",
                     ],
                     "UIUserInterfaceStyle": "Light",

--- a/App/Project.swift
+++ b/App/Project.swift
@@ -14,7 +14,10 @@ let project = Project(
             deploymentTargets: .iOS("17.0"),
             infoPlist: .extendingDefault(
                 with: [
-                    "UILaunchScreen": [:],
+                    "UILaunchScreen": [
+                        "UIColorName": "HopesBackground",
+                        "UIImageName": "AppIcon",
+                    ],
                     "UIUserInterfaceStyle": "Light",
                     "NSAppTransportSecurity": [
                         "NSExceptionDomains": [

--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -4,22 +4,51 @@ import SwiftUI
 @main
 @MainActor
 struct HopesApp: App {
+    @State private var isSplashVisible = true
+
     var body: some Scene {
         WindowGroup {
-            LoginFlowView(
-                isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login"),
-                isSignUpInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-sign-up"),
-                isOnboardingInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-onboarding"),
-                isChatHomeInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-home"),
-                isChatDetailInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-detail"),
-                isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence"),
-                isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history"),
-                isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page"),
-                isSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-settings"),
-                isGeneralSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-general-settings"),
-                isPersonalSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-personal-settings"),
-                isContactInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-contact")
-            )
+            ZStack {
+                LoginFlowView(
+                    isLoginInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-login"),
+                    isSignUpInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-sign-up"),
+                    isOnboardingInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-onboarding"),
+                    isChatHomeInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-home"),
+                    isChatDetailInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-chat-detail"),
+                    isAnswerEvidenceInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-answer-evidence"),
+                    isConversationHistoryInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-conversation-history"),
+                    isMyPageInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-my-page"),
+                    isSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-settings"),
+                    isGeneralSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-general-settings"),
+                    isPersonalSettingsInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-personal-settings"),
+                    isContactInitiallyOpen: ProcessInfo.processInfo.arguments.contains("--show-contact")
+                )
+
+                if isSplashVisible {
+                    HopesLaunchView()
+                        .transition(.opacity)
+                }
+            }
+            .task {
+                try? await Task.sleep(for: .milliseconds(450))
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeOut(duration: 0.18)) {
+                    isSplashVisible = false
+                }
+            }
         }
+    }
+}
+
+private struct HopesLaunchView: View {
+    var body: some View {
+        Color.hopesBackground
+            .ignoresSafeArea()
+            .overlay {
+                Image("AppIcon")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 96, height: 96)
+            }
     }
 }

--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -29,7 +29,7 @@ struct HopesApp: App {
                 }
             }
             .task {
-                try? await Task.sleep(for: .seconds(2))
+                try? await Task.sleep(for: .seconds(1))
                 guard !Task.isCancelled else { return }
                 isSplashVisible = false
             }
@@ -42,7 +42,10 @@ private struct HopesLaunchView: View {
         Color.hopesHeroGradient
             .ignoresSafeArea()
             .overlay {
-                HopesLogo(placement: .onBrand, size: .large)
+                Image("AppIcon60x60")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 104, height: 104)
             }
     }
 }

--- a/App/Sources/HopesApp.swift
+++ b/App/Sources/HopesApp.swift
@@ -26,15 +26,12 @@ struct HopesApp: App {
 
                 if isSplashVisible {
                     HopesLaunchView()
-                        .transition(.opacity)
                 }
             }
             .task {
-                try? await Task.sleep(for: .milliseconds(450))
+                try? await Task.sleep(for: .seconds(2))
                 guard !Task.isCancelled else { return }
-                withAnimation(.easeOut(duration: 0.18)) {
-                    isSplashVisible = false
-                }
+                isSplashVisible = false
             }
         }
     }
@@ -42,13 +39,10 @@ struct HopesApp: App {
 
 private struct HopesLaunchView: View {
     var body: some View {
-        Color.hopesBackground
+        Color.hopesHeroGradient
             .ignoresSafeArea()
             .overlay {
-                Image("AppIcon")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 96, height: 96)
+                HopesLogo(placement: .onBrand, size: .large)
             }
     }
 }

--- a/Sources/HopesDesignSystem/Components/HopesLogo.swift
+++ b/Sources/HopesDesignSystem/Components/HopesLogo.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 public struct HopesLogo: View {
     public enum Placement: Sendable {
@@ -27,12 +28,7 @@ public struct HopesLogo: View {
 
     public var body: some View {
         HStack(spacing: size == .compact ? 12 : 0) {
-            Text("h")
-                .font(.system(size: iconFontSize, weight: .bold))
-                .foregroundStyle(Color.hopesBrandPrimary)
-                .frame(width: iconSize, height: iconSize)
-                .background(.white)
-                .clipShape(RoundedRectangle(cornerRadius: iconCornerRadius))
+            logoImage
 
             if size == .compact {
                 VStack(alignment: .leading, spacing: 0) {
@@ -55,12 +51,33 @@ public struct HopesLogo: View {
         size == .compact ? 42 : 74
     }
 
-    private var iconFontSize: CGFloat {
-        size == .compact ? 26 : 40
+    @ViewBuilder
+    private var logoImage: some View {
+        if let image = appIconImage {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: iconSize, height: iconSize)
+        } else {
+            Text("h")
+                .font(.system(size: size == .compact ? 26 : 40, weight: .bold))
+                .foregroundStyle(Color.hopesBrandPrimary)
+                .frame(width: iconSize, height: iconSize)
+                .background(.white)
+                .clipShape(RoundedRectangle(cornerRadius: size == .compact ? 12 : 18))
+        }
     }
 
-    private var iconCornerRadius: CGFloat {
-        size == .compact ? 12 : 18
+    private var appIconImage: UIImage? {
+        if let image = UIImage(named: "AppIcon60x60", in: .main, compatibleWith: nil) {
+            return image
+        }
+
+        let iconURL = Bundle.main
+            .urls(forResourcesWithExtension: "png", subdirectory: nil)?
+            .first { $0.deletingPathExtension().lastPathComponent.hasPrefix("AppIcon60x60") }
+
+        return iconURL.flatMap { UIImage(contentsOfFile: $0.path) }
     }
 
     private var primaryTextColor: Color {


### PR DESCRIPTION
## 변경 사항

- 런치 화면이 실제 앱 아이콘 번들 이미지를 표시하도록 수정
- 런치 노출 시간을 2초에서 1초로 단축
- Swift Package 화면에서 누락되던 공용 Hopes 로고를 앱 번들 아이콘으로 복구

## 원인

앱 아이콘 세트 이름인 `AppIcon`을 일반 이미지 리소스처럼 조회해 런치 및 패키지 화면에서 이미지 로딩이 실패했습니다.

## 검증

- `tuist generate` 성공
- Hopes iOS Simulator 빌드 성공
- iPhone 17 Pro Simulator에서 런치 로고 확인
- Onboarding 및 ChatHome의 헤더·중앙 로고 확인

Closes #139
