### PR TITLE
ChatHome 키보드 UX 및 비밀번호 재설정 인증 흐름 개선

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
@@ -3,8 +3,7 @@ import UIKit
 
 public struct ChatHomeView: View {
     @State private var selectedTab: HopesTab = .chat
-    @State private var keyboardFrame: CGRect?
-    @State private var keyboardAnimationDuration: Double = 0.25
+    @State private var isKeyboardVisible = false
     @Binding private var message: String
     @FocusState private var isInputFocused: Bool
 
@@ -32,58 +31,60 @@ public struct ChatHomeView: View {
     }
 
     public var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .top) {
+        ScrollViewReader { proxy in
+            ScrollView(.vertical, showsIndicators: false) {
                 fixedDesign
-                    .offset(y: -keyboardShift(in: geometry))
-
-                composer
-                    .padding(.horizontal, 24)
-                    .padding(.top, composerTop(in: geometry))
-
-                if !isInputFocused && keyboardFrame == nil {
-                    HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                        .frame(maxHeight: .infinity, alignment: .bottom)
-                }
+                    .frame(height: 728)
+                    .id("chat-home-top")
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .ignoresSafeArea(.container, edges: .bottom)
-            .ignoresSafeArea(.keyboard, edges: .bottom)
-            .onChange(of: isInputFocused) { _, isFocused in
-                if !isFocused {
-                    withAnimation(.easeOut(duration: keyboardAnimationDuration)) {
-                        keyboardFrame = nil
+            .scrollDisabled(!isInputFocused)
+            .scrollDismissesKeyboard(.interactively)
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                VStack(spacing: 0) {
+                    composer
+                        .padding(.horizontal, 24)
+
+                    if !isInputFocused && !isKeyboardVisible {
+                        Color.clear
+                            .frame(height: 10)
+
+                        HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+                    } else {
+                        Color.clear
+                            .frame(height: 10)
                     }
                 }
-            }
-            .onReceive(
-                NotificationCenter.default.publisher(
-                    for: UIResponder.keyboardWillChangeFrameNotification
-                )
-            ) { notification in
-                updateKeyboardFrame(from: notification)
+                .background(Color.hopesBackground)
             }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: UIResponder.keyboardWillShowNotification
                 )
-            ) { notification in
-                updateKeyboardFrame(from: notification)
+            ) { _ in
+                isKeyboardVisible = true
+            }
+            .onReceive(
+                NotificationCenter.default.publisher(
+                    for: UIResponder.keyboardDidShowNotification
+                )
+            ) { _ in
+                withAnimation(.easeOut(duration: 0.2)) {
+                    proxy.scrollTo(1, anchor: .bottom)
+                }
             }
             .onReceive(
                 NotificationCenter.default.publisher(
                     for: UIResponder.keyboardWillHideNotification
                 )
-            ) { notification in
-                updateKeyboardAnimation(from: notification)
-                withAnimation(.easeOut(duration: keyboardAnimationDuration)) {
-                    keyboardFrame = nil
+            ) { _ in
+                isKeyboardVisible = false
+                withAnimation(.easeOut(duration: 0.2)) {
+                    proxy.scrollTo("chat-home-top", anchor: .top)
                 }
             }
+            .background(Color.hopesBackground.ignoresSafeArea())
+            .ignoresSafeArea(.container, edges: [.top, .bottom])
         }
-        .background(Color.hopesBackground.ignoresSafeArea())
-        .ignoresSafeArea(.container, edges: .top)
-        .ignoresSafeArea(.keyboard, edges: .bottom)
     }
 
     private var fixedDesign: some View {
@@ -123,13 +124,14 @@ public struct ChatHomeView: View {
             )
 
             VStack(spacing: 6) {
-                ForEach(suggestions, id: \.1) { icon, title in
-                    HopesQuestionCard(title: title) {
+                ForEach(suggestions.indices, id: \.self) { index in
+                    HopesQuestionCard(title: suggestions[index].1) {
                         isInputFocused = false
-                        message = title
+                        message = suggestions[index].1
                     } icon: {
-                        Text(icon)
+                        Text(suggestions[index].0)
                     }
+                    .id(index)
                 }
             }
             .padding(.horizontal, 24)
@@ -141,59 +143,6 @@ public struct ChatHomeView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .ignoresSafeArea(.container, edges: .bottom)
-    }
-
-    private func updateKeyboardFrame(from notification: Notification) {
-        guard
-            let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect,
-            frame.height > 0
-        else {
-            return
-        }
-
-        updateKeyboardAnimation(from: notification)
-
-        let convertedFrame = globalKeyboardFrame(for: frame)
-        withAnimation(.easeOut(duration: keyboardAnimationDuration)) {
-            keyboardFrame = convertedFrame
-        }
-    }
-
-    private func globalKeyboardFrame(for screenFrame: CGRect) -> CGRect {
-        #if os(iOS)
-        guard let window = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
-            return screenFrame
-        }
-
-        return window.convert(screenFrame, from: window.screen.coordinateSpace)
-        #else
-        return screenFrame
-        #endif
-    }
-
-    private func updateKeyboardAnimation(from notification: Notification) {
-        if let duration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? Double {
-            keyboardAnimationDuration = duration
-        }
-    }
-
-    private func keyboardShift(in geometry: GeometryProxy) -> CGFloat {
-        guard isInputFocused, let keyboardFrame else {
-            return 0
-        }
-
-        let rootFrame = geometry.frame(in: .global)
-        let keyboardTop = keyboardFrame.minY - rootFrame.minY
-        let composerTop = max(0, keyboardTop - 12 - 52)
-
-        return max(0, 728 - composerTop)
-    }
-
-    private func composerTop(in geometry: GeometryProxy) -> CGFloat {
-        728 - keyboardShift(in: geometry)
     }
 
     private var header: some View {

--- a/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
+++ b/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
@@ -87,15 +87,15 @@ public struct PasswordResetView: View {
                         .keyboardType(.numberPad)
                         .textContentType(.oneTimeCode)
 
-                    Button("번호 발송", action: requestCode)
+                    Button(codeButtonTitle, action: handleCodeButton)
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.white)
                         .frame(width: 88, height: 43)
                         .background(Color.hopesBrandPrimary)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .buttonStyle(.plain)
-                        .disabled(isLoading)
-                        .opacity(isLoading ? 0.45 : 1)
+                        .disabled(!isCodeButtonEnabled)
+                        .opacity(isCodeButtonEnabled ? 1 : 0.45)
                 }
 
                 fieldTitle("비밀번호", top: 8)
@@ -151,10 +151,29 @@ public struct PasswordResetView: View {
             .padding(.bottom, 34)
         }
         .ignoresSafeArea(.keyboard, edges: .bottom)
+        .onChange(of: codeRequested) { _, requested in
+            if requested {
+                focusedField = .code
+            }
+        }
     }
 
     private var canSubmit: Bool {
-        !isLoading && isEmailValid && isCodeValid && PasswordPolicy.isValid(newPassword)
+        !isLoading
+            && codeRequested
+            && isEmailValid
+            && isCodeValid
+            && PasswordPolicy.isValid(newPassword)
+    }
+
+    private var codeButtonTitle: String {
+        if isLoading { return "처리 중" }
+        return codeRequested ? "인증하기" : "번호 발송"
+    }
+
+    private var isCodeButtonEnabled: Bool {
+        guard !isLoading else { return false }
+        return codeRequested ? canSubmit : isEmailValid
     }
 
     private var isEmailValid: Bool {
@@ -166,9 +185,14 @@ public struct PasswordResetView: View {
         code.range(of: #"^\d{6}$"#, options: .regularExpression) != nil
     }
 
-    private func requestCode() {
+    private func handleCodeButton() {
         focusedField = nil
-        onRequestCode()
+        if codeRequested {
+            guard canSubmit else { return }
+            onReset()
+        } else {
+            onRequestCode()
+        }
     }
 
     private func fieldTitle(_ title: String, top: CGFloat) -> some View {


### PR DESCRIPTION
Closes #141

## 변경 사항

- ChatHome에서 키보드가 열릴 때 composer를 키보드 바로 위에 유지하고 입력 내용과 전송 버튼이 보이도록 개선했습니다.
- 키보드가 열린 동안 TabBar를 숨기고 질문 카드 영역을 이동하며, 키보드가 닫히면 초기 위치로 복원합니다.
- 비밀번호 재설정 버튼을 인증번호 발송 전/후 상태로 분기했습니다.
- 인증번호 발송 성공 후 코드 입력란으로 포커스를 이동하고, 6자리 코드와 비밀번호 정책을 검증한 뒤 기존 재설정 API를 호출합니다.

## 원인

- ChatHome의 수동 키보드 프레임/offset 계산이 실제 composer 노출을 안정적으로 보장하지 못했습니다.
- 비밀번호 재설정 UI가 인증번호 발송과 최종 재설정 단계를 하나의 명확한 상태 흐름으로 연결하지 못했습니다.

## 영향

- 사용자는 ChatHome에서 키보드가 열린 상태에서도 입력값과 전송 버튼을 확인할 수 있습니다.
- 비밀번호 재설정은 기존 requestPasswordResetCode 및 resetPassword API를 유지하면서 1차 발송과 2차 인증/재설정 흐름으로 동작합니다.

## 검증

- `git diff --check`
- `xcodebuild -project App/Hopes.xcodeproj -scheme Hopes -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /private/tmp/hopes-password-reset-branch CODE_SIGNING_ALLOWED=NO build`
- 결과: BUILD SUCCEEDED
- Simulator에서 ChatHome 키보드 표시, 두 개 질문 카드 노출, composer 입력값 및 전송 버튼 표시를 확인했습니다.

