### PR TITLE
비밀번호 재설정 인증 버튼 활성화 및 완료 상태 구현

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -27,6 +27,7 @@ public struct LoginFlowView: View {
     @State private var passwordResetCode = ""
     @State private var passwordResetNewPassword = ""
     @State private var isPasswordResetCodeRequested = false
+    @State private var isPasswordResetVerified = false
     @State private var isResettingPassword = false
     @State private var passwordResetErrorMessage: String?
     @State private var signUpEmail = ""
@@ -135,11 +136,16 @@ public struct LoginFlowView: View {
                     code: $passwordResetCode,
                     newPassword: $passwordResetNewPassword,
                     codeRequested: isPasswordResetCodeRequested,
+                    isVerified: isPasswordResetVerified,
                     isLoading: isResettingPassword,
                     errorMessage: passwordResetErrorMessage,
-                    onBack: { transition(to: .login) },
+                    onBack: {
+                        clearPasswordResetState()
+                        transition(to: .login)
+                    },
                     onRequestCode: requestPasswordResetCode,
-                    onReset: resetPassword
+                    onReset: resetPassword,
+                    onComplete: completePasswordReset
                 )
                 .transition(.opacity)
 
@@ -437,6 +443,7 @@ public struct LoginFlowView: View {
     private func requestPasswordResetCode() {
         guard !isResettingPassword else { return }
         isResettingPassword = true
+        isPasswordResetVerified = false
         passwordResetErrorMessage = nil
         Task {
             do {
@@ -456,6 +463,10 @@ public struct LoginFlowView: View {
 
     private func resetPassword() {
         guard !isResettingPassword else { return }
+        guard PasswordPolicy.isValid(passwordResetNewPassword) else {
+            passwordResetErrorMessage = "비밀번호는 영문과 숫자를 포함해 8~15자로 입력해주세요."
+            return
+        }
         isResettingPassword = true
         passwordResetErrorMessage = nil
         Task {
@@ -467,11 +478,7 @@ public struct LoginFlowView: View {
                 )
                 await MainActor.run {
                     isResettingPassword = false
-                    isPasswordResetCodeRequested = false
-                    passwordResetCode = ""
-                    passwordResetNewPassword = ""
-                    password = ""
-                    transition(to: .login)
+                    isPasswordResetVerified = true
                 }
             } catch {
                 await MainActor.run {
@@ -480,6 +487,22 @@ public struct LoginFlowView: View {
                 }
             }
         }
+    }
+
+    private func completePasswordReset() {
+        guard isPasswordResetVerified else { return }
+        clearPasswordResetState()
+        password = ""
+        transition(to: .login)
+    }
+
+    private func clearPasswordResetState() {
+        isPasswordResetCodeRequested = false
+        isPasswordResetVerified = false
+        isResettingPassword = false
+        passwordResetCode = ""
+        passwordResetNewPassword = ""
+        passwordResetErrorMessage = nil
     }
 
     private func loadProfile() {

--- a/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
+++ b/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
@@ -13,32 +13,38 @@ public struct PasswordResetView: View {
     @FocusState private var focusedField: ResetField?
     @State private var isPasswordVisible = false
     private let codeRequested: Bool
+    private let isVerified: Bool
     private let isLoading: Bool
     private let errorMessage: String?
     private let onBack: () -> Void
     private let onRequestCode: () -> Void
     private let onReset: () -> Void
+    private let onComplete: () -> Void
 
     public init(
         email: Binding<String>,
         code: Binding<String>,
         newPassword: Binding<String>,
         codeRequested: Bool = false,
+        isVerified: Bool = false,
         isLoading: Bool = false,
         errorMessage: String? = nil,
         onBack: @escaping () -> Void = {},
         onRequestCode: @escaping () -> Void = {},
-        onReset: @escaping () -> Void = {}
+        onReset: @escaping () -> Void = {},
+        onComplete: @escaping () -> Void = {}
     ) {
         _email = email
         _code = code
         _newPassword = newPassword
         self.codeRequested = codeRequested
+        self.isVerified = isVerified
         self.isLoading = isLoading
         self.errorMessage = errorMessage
         self.onBack = onBack
         self.onRequestCode = onRequestCode
         self.onReset = onReset
+        self.onComplete = onComplete
     }
 
     public var body: some View {
@@ -78,6 +84,7 @@ public struct PasswordResetView: View {
                     .textInputAutocapitalization(.never)
                     .keyboardType(.emailAddress)
                     .textContentType(.emailAddress)
+                    .disabled(isVerified)
 
                 fieldTitle("인증번호", top: 8)
                 HStack(spacing: 10) {
@@ -86,6 +93,7 @@ public struct PasswordResetView: View {
                         .focused($focusedField, equals: .code)
                         .keyboardType(.numberPad)
                         .textContentType(.oneTimeCode)
+                        .disabled(isVerified)
 
                     Button(codeButtonTitle, action: handleCodeButton)
                         .font(.system(size: 14, weight: .semibold))
@@ -95,7 +103,7 @@ public struct PasswordResetView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 14))
                         .buttonStyle(.plain)
                         .disabled(!isCodeButtonEnabled)
-                        .opacity(isCodeButtonEnabled ? 1 : 0.45)
+                        .opacity(isVerified || isCodeButtonEnabled ? 1 : 0.45)
                 }
 
                 fieldTitle("비밀번호", top: 8)
@@ -110,6 +118,7 @@ public struct PasswordResetView: View {
                     .textFieldStyle(HopesResetFieldStyle())
                     .focused($focusedField, equals: .newPassword)
                     .textContentType(.newPassword)
+                    .disabled(isVerified)
 
                     Button {
                         isPasswordVisible.toggle()
@@ -141,9 +150,9 @@ public struct PasswordResetView: View {
 
                 Spacer()
 
-                HopesButton("완료", size: .large, isEnabled: canSubmit) {
+                HopesButton("완료", size: .large, isEnabled: canComplete) {
                     focusedField = nil
-                    onReset()
+                    onComplete()
                 }
             }
             .padding(.horizontal, 28)
@@ -158,22 +167,19 @@ public struct PasswordResetView: View {
         }
     }
 
-    private var canSubmit: Bool {
-        !isLoading
-            && codeRequested
-            && isEmailValid
-            && isCodeValid
-            && PasswordPolicy.isValid(newPassword)
+    private var canComplete: Bool {
+        isVerified && !isLoading
     }
 
     private var codeButtonTitle: String {
+        if isVerified { return "인증완료" }
         if isLoading { return "처리 중" }
         return codeRequested ? "인증하기" : "번호 발송"
     }
 
     private var isCodeButtonEnabled: Bool {
-        guard !isLoading else { return false }
-        return codeRequested ? canSubmit : isEmailValid
+        guard !isLoading, !isVerified else { return false }
+        return codeRequested ? isCodeValid : isEmailValid
     }
 
     private var isEmailValid: Bool {
@@ -188,7 +194,7 @@ public struct PasswordResetView: View {
     private func handleCodeButton() {
         focusedField = nil
         if codeRequested {
-            guard canSubmit else { return }
+            guard isCodeValid else { return }
             onReset()
         } else {
             onRequestCode()


### PR DESCRIPTION
Closes #143

## 변경 사항

- 인증번호 발송 완료 후 6자리 코드를 입력하면 `인증하기` 버튼이 활성화되도록 조건을 분리했습니다.
- `인증하기`에서 기존 `/api/password/reset` API를 호출하도록 유지했습니다.
- API 성공 직후 로그인 화면으로 이동하지 않고 버튼을 `인증완료`로 표시합니다.
- 인증 완료 후 하단 `완료` 버튼으로 로그인 화면에 복귀하도록 단계를 분리했습니다.
- 인증 완료 상태에서는 이메일, 인증번호, 새 비밀번호 입력값을 잠가 성공 이후 값 변경을 방지합니다.
- 뒤로가기 및 완료 시 비밀번호 재설정 임시 상태를 정리합니다.

## 원인

인증 버튼 활성화 조건이 인증번호 6자리뿐 아니라 새 비밀번호 정책까지 포함한 전체 제출 조건에 결합되어 있었습니다. 또한 재설정 API 성공 직후 화면이 닫혀 `인증완료` 상태를 표시할 수 없었습니다.

## 서버 흐름

서버에는 별도의 비밀번호 인증번호 확인 API가 없으며 `/api/password/reset`이 코드 검증과 비밀번호 변경을 함께 처리합니다. 따라서 실제 API 성공 시점을 인증 완료 상태로 사용합니다.

## 검증

- `git diff --check`
- `xcodebuild -project App/Hopes.xcodeproj -scheme Hopes -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -derivedDataPath /private/tmp/hopes-password-reset-verification CODE_SIGNING_ALLOWED=NO build`
- 결과: BUILD SUCCEEDED

