### PR TITLE
fix: 기록 화면 검색 아이콘 크기 수정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -109,8 +109,8 @@ public struct ConversationHistoryView: View {
                 .onSubmit(performSearch)
 
             Button(action: performSearch) {
-                Text("⌕")
-                    .font(.subheadline.weight(.semibold))
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(Color.hopesTextPrimary)
                     .frame(width: 38, height: 41)
             }


### PR DESCRIPTION
## 변경 사항
- 기록 화면 검색 버튼의 임시 문자 `⌕`를 시스템 `magnifyingglass` SF Symbol로 교체했습니다.
- 검색 버튼의 기존 38×41pt 터치 영역과 검색 동작은 유지했습니다.
- 아이콘을 18pt semibold로 표시해 버튼 대비 시각적 크기를 정상화했습니다.

## 원인
- 기존 구현은 아이콘 에셋이 아닌 텍스트 문자를 사용해 glyph 자체가 작게 렌더링되었습니다.

## 영향 범위
- `ConversationHistoryView` 검색 버튼 아이콘만 변경합니다.
- 기록 검색 로직, 레이아웃, 다른 화면에는 영향이 없습니다.

## 검증
- `git diff --check` 통과
- Hopes scheme / iPhone 17 Pro Simulator 대상 `xcodebuild` 성공

Closes #145
