### PR TITLE
fix: 비밀번호 재설정 피드백과 버튼 터치 범위 개선

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesButton.swift
+++ b/Sources/HopesDesignSystem/Components/HopesButton.swift
@@ -118,6 +118,7 @@ public struct HopesButton: View {
             )
             .background(backgroundColor)
             .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+            .contentShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)
                     .stroke(borderColor, lineWidth: borderColor == .clear ? 0 : 1)

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -487,17 +487,20 @@ public struct LoginView: View {
                     .accessibilityLabel("비밀번호")
                     .id(LoginField.password)
 
-                Button {
-                    focusedField = nil
-                    onForgotPassword()
-                } label: {
-                    Text("비밀번호를 잊으셨나요?")
-                }
+                HStack(spacing: 0) {
+                    Spacer()
+
+                    Button {
+                        focusedField = nil
+                        onForgotPassword()
+                    } label: {
+                        Text("비밀번호를 잊으셨나요?")
+                    }
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(Color.hopesBrandPrimary)
                     .buttonStyle(.plain)
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-                    .padding(.top, 8)
+                }
+                .padding(.top, 8)
             }
             .padding(.horizontal, 32)
             .padding(.top, 68)
@@ -522,16 +525,21 @@ public struct LoginView: View {
                     .padding(.top, 407)
             }
 
-            Button {
-                focusedField = nil
-                onSignUp()
-            } label: {
-                Text("계정이 없으신가요?  회원가입")
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Color.hopesTextSecondary)
-                    .frame(maxWidth: .infinity)
+            HStack(spacing: 0) {
+                Spacer()
+
+                Button {
+                    focusedField = nil
+                    onSignUp()
+                } label: {
+                    Text("계정이 없으신가요?  회원가입")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(Color.hopesTextSecondary)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
             }
-            .buttonStyle(.plain)
             .padding(.horizontal, 32)
             .padding(.top, errorMessage == nil ? 422 : 450)
         }

--- a/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
+++ b/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
@@ -86,6 +86,10 @@ public struct PasswordResetView: View {
                     .textContentType(.emailAddress)
                     .disabled(isVerified)
 
+                if let emailErrorMessage {
+                    feedbackText(emailErrorMessage, color: Color.hopesDanger)
+                }
+
                 fieldTitle("인증번호", top: 8)
                 HStack(spacing: 10) {
                     TextField("숫자 6자리", text: $code)
@@ -101,9 +105,16 @@ public struct PasswordResetView: View {
                         .frame(width: 88, height: 43)
                         .background(Color.hopesBrandPrimary)
                         .clipShape(RoundedRectangle(cornerRadius: 14))
+                        .contentShape(RoundedRectangle(cornerRadius: 14))
                         .buttonStyle(.plain)
                         .disabled(!isCodeButtonEnabled)
                         .opacity(isVerified || isCodeButtonEnabled ? 1 : 0.45)
+                }
+
+                if isVerified {
+                    feedbackText("인증이 완료되었습니다.", color: Color.hopesSuccess)
+                } else if let codeErrorMessage {
+                    feedbackText(codeErrorMessage, color: Color.hopesDanger)
                 }
 
                 fieldTitle("비밀번호", top: 8)
@@ -132,6 +143,8 @@ public struct PasswordResetView: View {
                     .buttonStyle(.plain)
                 }
 
+                feedbackText(passwordFeedbackMessage, color: passwordFeedbackColor)
+
                 Color.clear
                     .frame(height: 0)
                     .onChange(of: code) { _, newValue in
@@ -140,13 +153,6 @@ public struct PasswordResetView: View {
                             code = filtered
                         }
                     }
-
-                if let errorMessage {
-                    Text(errorMessage)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(Color.hopesDanger)
-                        .padding(.top, 12)
-                }
 
                 Spacer()
 
@@ -172,9 +178,40 @@ public struct PasswordResetView: View {
     }
 
     private var codeButtonTitle: String {
-        if isVerified { return "인증완료" }
+        if isVerified { return "인증 완료" }
         if isLoading { return "처리 중" }
         return codeRequested ? "인증하기" : "번호 발송"
+    }
+
+    private var emailErrorMessage: String? {
+        guard let errorMessage, errorMessage.contains("이메일") || errorMessage.contains("회원") else {
+            return nil
+        }
+        return errorMessage
+    }
+
+    private var codeErrorMessage: String? {
+        guard let errorMessage,
+              !errorMessage.contains("이메일"),
+              !errorMessage.contains("회원"),
+              !errorMessage.contains("비밀번호")
+        else { return nil }
+        return errorMessage
+    }
+
+    private var passwordFeedbackMessage: String {
+        if let errorMessage, errorMessage.contains("비밀번호") {
+            return errorMessage
+        }
+        return "영문과 숫자를 포함해 8~15자로 입력해주세요."
+    }
+
+    private var passwordFeedbackColor: Color {
+        guard !newPassword.isEmpty else { return Color.hopesTextSecondary }
+        if let errorMessage, errorMessage.contains("비밀번호") {
+            return Color.hopesDanger
+        }
+        return PasswordPolicy.isValid(newPassword) ? Color.hopesTextSecondary : Color.hopesDanger
     }
 
     private var isCodeButtonEnabled: Bool {
@@ -207,6 +244,13 @@ public struct PasswordResetView: View {
             .foregroundStyle(Color.hopesTextPrimary)
             .padding(.top, top)
             .padding(.bottom, 8)
+    }
+
+    private func feedbackText(_ message: String, color: Color) -> some View {
+        Text(message)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(color)
+            .padding(.top, 6)
     }
 }
 

--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -311,17 +311,22 @@ public struct SignUpView: View {
     }
 
     private var loginLink: some View {
-        Button {
-            focusedField = nil
-            onGoToLogin()
-        } label: {
-            (Text("계정이 있으신가요?  ").foregroundStyle(Color.hopesTextSecondary)
-                + Text("로그인").foregroundStyle(Color.hopesBrandPrimary).underline())
-                .font(.footnote)
-                .frame(maxWidth: .infinity)
-                .frame(height: 18)
+        HStack(spacing: 0) {
+            Spacer()
+
+            Button {
+                focusedField = nil
+                onGoToLogin()
+            } label: {
+                (Text("계정이 있으신가요?  ").foregroundStyle(Color.hopesTextSecondary)
+                    + Text("로그인").foregroundStyle(Color.hopesBrandPrimary).underline())
+                    .font(.footnote)
+                    .frame(height: 18)
+            }
+            .buttonStyle(.plain)
+
+            Spacer()
         }
-        .buttonStyle(.plain)
     }
 
     private var normalizedEmail: String {


### PR DESCRIPTION
## 변경 사항
- 비밀번호 재설정 오류를 이메일/인증번호/비밀번호 입력 영역별로 표시
- 실제 재설정 API 성공 후 인증번호 아래에 초록색 인증 완료 안내 표시
- 비밀번호 양식 안내와 형식 오류를 비밀번호 입력창 아래에 표시
- 공용 버튼과 로그인/회원가입 링크의 터치 범위를 보이는 영역에 맞춤

## 서버 제약
현재 서버는 인증번호만 확인하는 별도 API 없이 이메일+인증번호+새 비밀번호를 함께 받는 `/api/password/reset`만 제공합니다. 따라서 초록색 인증 완료는 실제 재설정 성공 후 표시합니다.

## 검증
- `git diff --check`
- `xcodebuild -project App/Hopes.xcodeproj -scheme Hopes -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath /private/tmp/hopes-password-reset-feedback CODE_SIGNING_ALLOWED=NO build`

Closes #147