### PR TITLE
fix: 기록 문구와 탭바 선택 아이콘 스타일 수정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -31,19 +31,6 @@ public enum HopesTab: String, CaseIterable, Sendable {
             "person"
         }
     }
-
-    fileprivate var selectedIconName: String {
-        switch self {
-        case .home:
-            "house.fill"
-        case .chat:
-            "message.fill"
-        case .history:
-            "clock.arrow.circlepath"
-        case .settings:
-            "person.fill"
-        }
-    }
 }
 
 public struct HopesTabBar: View {
@@ -89,14 +76,7 @@ public struct HopesTabBar: View {
             onSelect(tab)
         } label: {
             ZStack(alignment: .top) {
-                if selection == tab && tab != .history && tab != .chat {
-                    Capsule()
-                        .fill(Color.hopesBrandTint)
-                        .frame(width: 60, height: 30)
-                        .position(x: 30, y: 27)
-                }
-
-                Image(systemName: selection == tab && tab != .chat ? tab.selectedIconName : tab.iconName)
+                Image(systemName: tab.iconName)
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundStyle(
                         selection == tab

--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -148,15 +148,9 @@ public struct ConversationHistoryView: View {
                 }
 
                 conversationSection(
-                    title: "지난 7일",
-                    conversations: filteredConversations(for: .recent)
+                    title: "모든 기록",
+                    conversations: filteredConversations
                 )
-
-                conversationSection(
-                    title: "이전",
-                    conversations: filteredConversations(for: .older)
-                )
-                .padding(.top, 20)
             }
         }
         .scrollIndicators(.hidden)
@@ -204,15 +198,10 @@ public struct ConversationHistoryView: View {
         }
     }
 
-    private func filteredConversations(
-        for period: Conversation.Period
-    ) -> [Conversation] {
+    private var filteredConversations: [Conversation] {
         conversations.filter { conversation in
-            conversation.period == period
-                && (
-                    trimmedQuery.isEmpty
-                        || conversation.title.localizedCaseInsensitiveContains(trimmedQuery)
-                )
+            trimmedQuery.isEmpty
+                || conversation.title.localizedCaseInsensitiveContains(trimmedQuery)
         }
     }
 


### PR DESCRIPTION
## 변경 사항
- 기록 목록을 기간 구분 없이 `모든 기록`으로 통합
- `이전` 섹션과 중복 빈 결과 문구 제거
- 홈/채팅/기록/마이페이지 선택 아이콘을 파란 외곽선 스타일로 통일
- 홈/마이페이지 선택 pill 및 채움 아이콘 제거

## 검증
- `git diff --check` 통과
- iPhone 17 Pro Simulator 대상 Hopes 빌드 성공
- Simulator에서 홈/기록/마이페이지 선택 상태 및 기록 화면 확인

Closes #149