### PR TITLE
fix: 기록 목록을 검색창 아래로 이동

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -76,7 +76,7 @@ public struct ConversationHistoryView: View {
 
             conversationList
                 .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 282)
+                .padding(.top, 257)
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)


### PR DESCRIPTION
## 변경 사항
- 기록 목록 시작 위치를 검색창 아래 8pt 간격으로 이동
- 목록 및 검색창 내부 디자인은 유지

## 검증
- `git diff --check` 통과
- iPhone 17 Pro Simulator 대상 Hopes 빌드 성공
- Simulator에서 검색창과 기록 영역 간격 확인

Closes #151