### PR TITLE
온보딩 하단 탭 화면 이동 연결

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -166,10 +166,13 @@ public struct LoginFlowView: View {
                 .transition(.opacity)
 
             case .onboarding:
-                OnboardingView {
-                    onStartChat()
-                    transition(to: .chatHome)
-                }
+                OnboardingView(
+                    onStartChat: {
+                        onStartChat()
+                        transition(to: .chatHome)
+                    },
+                    onSelectTab: navigateFromTab
+                )
                     .transition(.opacity)
 
             case .chatHome:

--- a/Sources/HopesDesignSystem/Screens/OnboardingView.swift
+++ b/Sources/HopesDesignSystem/Screens/OnboardingView.swift
@@ -4,9 +4,14 @@ public struct OnboardingView: View {
     @State private var selectedTab: HopesTab = .home
 
     private let onStartChat: () -> Void
+    private let onSelectTab: (HopesTab) -> Void
 
-    public init(onStartChat: @escaping () -> Void = {}) {
+    public init(
+        onStartChat: @escaping () -> Void = {},
+        onSelectTab: @escaping (HopesTab) -> Void = { _ in }
+    ) {
         self.onStartChat = onStartChat
+        self.onSelectTab = onSelectTab
     }
 
     public var body: some View {
@@ -58,7 +63,7 @@ public struct OnboardingView: View {
             )
             .padding(.top, 706)
 
-            HopesTabBar(selection: $selectedTab)
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
         }
         .ignoresSafeArea()


### PR DESCRIPTION
## 변경 사항\n- 온보딩의 HopesTabBar 선택을 기존 LoginFlowView 라우팅에 연결\n- 채팅 탭은 ChatHome, 기록 탭은 ConversationHistory, 마이페이지 탭은 MyPage로 이동\n- 기존 채팅 시작하기 버튼과 온보딩 UI 유지\n\n## 검증\n- Hopes iPhone 17 Pro Simulator 빌드 성공\n- git diff --check 통과\n\nCloses #155