### PR TITLE
하단 탭바 아이콘 참고 디자인 조정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -77,7 +77,7 @@ public struct HopesTabBar: View {
         } label: {
             ZStack(alignment: .top) {
                 Image(systemName: tab.iconName)
-                    .font(.system(size: 18, weight: .semibold))
+                    .font(.system(size: 24, weight: .regular))
                     .foregroundStyle(
                         selection == tab
                             ? Color(red: 13 / 255, green: 138 / 255, blue: 229 / 255)


### PR DESCRIPTION
## 변경 사항
- 기존 SF Symbol 종류와 선택 상태 로직 유지
- 탭 아이콘 공통 렌더링을 24pt regular로 조정
- TabBar 높이·위치·텍스트·네비게이션은 변경하지 않음

## 검증
- Hopes iPhone 17 Pro Simulator 빌드 성공
- git diff --check 통과

Closes #157