### PR TITLE
chore:[#159] 하단 탭바 오류 최종 수정 완료

### DIFF
--- a/Resources/Assets.xcassets/HopesTabChat.imageset/Contents.json
+++ b/Resources/Assets.xcassets/HopesTabChat.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "HopesTabChat.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Resources/Assets.xcassets/HopesTabChat.imageset/HopesTabChat.svg
+++ b/Resources/Assets.xcassets/HopesTabChat.imageset/HopesTabChat.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 12C4 7.85786 7.85786 4.5 12.5 4.5C17.1421 4.5 21 7.85786 21 12C21 16.1421 17.1421 19.5 12.5 19.5H8.5L4.5 22V17.9C4.18 17.55 4 17.1 4 12Z" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Resources/Assets.xcassets/HopesTabHistory.imageset/Contents.json
+++ b/Resources/Assets.xcassets/HopesTabHistory.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "HopesTabHistory.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Resources/Assets.xcassets/HopesTabHistory.imageset/HopesTabHistory.svg
+++ b/Resources/Assets.xcassets/HopesTabHistory.imageset/HopesTabHistory.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12C21 16.9706 16.9706 21 12 21C9.13623 21 6.58252 19.6704 4.92896 17.5934" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 17V13H7" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 7.5V12L15 14" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Resources/Assets.xcassets/HopesTabHome.imageset/Contents.json
+++ b/Resources/Assets.xcassets/HopesTabHome.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "HopesTabHome.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Resources/Assets.xcassets/HopesTabHome.imageset/HopesTabHome.svg
+++ b/Resources/Assets.xcassets/HopesTabHome.imageset/HopesTabHome.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 10.5L12 3L21 10.5" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.5 9V20C5.5 20.5523 5.94772 21 6.5 21H9.5C10.0523 21 10.5 20.5523 10.5 20V15C10.5 14.4477 10.9477 14 11.5 14H12.5C13.0523 14 13.5 14.4477 13.5 15V20C13.5 20.5523 13.9477 21 14.5 21H17.5C18.0523 21 18.5 20.5523 18.5 20V9" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Resources/Assets.xcassets/HopesTabMyPage.imageset/Contents.json
+++ b/Resources/Assets.xcassets/HopesTabMyPage.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "HopesTabMyPage.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Resources/Assets.xcassets/HopesTabMyPage.imageset/HopesTabMyPage.svg
+++ b/Resources/Assets.xcassets/HopesTabMyPage.imageset/HopesTabMyPage.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12 11.5C13.933 11.5 15.5 9.933 15.5 8C15.5 6.067 13.933 4.5 12 4.5C10.067 4.5 8.5 6.067 8.5 8C8.5 9.933 10.067 11.5 12 11.5Z" stroke="#9CA3AF" stroke-width="1.8"/>
+<path d="M4.5 20C5.5 16.5 8.4 14.5 12 14.5C15.6 14.5 18.5 16.5 19.5 20" stroke="#9CA3AF" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -22,13 +22,13 @@ public enum HopesTab: String, CaseIterable, Sendable {
     fileprivate var iconName: String {
         switch self {
         case .home:
-            "house"
+            "HopesTabHome"
         case .chat:
-            "message"
+            "HopesTabChat"
         case .history:
-            "clock.arrow.circlepath"
+            "HopesTabHistory"
         case .settings:
-            "person"
+            "HopesTabMyPage"
         }
     }
 }
@@ -76,8 +76,10 @@ public struct HopesTabBar: View {
             onSelect(tab)
         } label: {
             ZStack(alignment: .top) {
-                Image(systemName: tab.iconName)
-                    .font(.system(size: 24, weight: .regular))
+                Image(tab.iconName)
+                    .resizable()
+                    .renderingMode(.template)
+                    .aspectRatio(contentMode: .fit)
                     .foregroundStyle(
                         selection == tab
                             ? Color(red: 13 / 255, green: 138 / 255, blue: 229 / 255)
@@ -104,6 +106,7 @@ public struct HopesTabBar: View {
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(selection == tab ? .isSelected : [])
     }
+
 }
 
 #Preview("Hopes Tab Bar") {


### PR DESCRIPTION
## 📌 변경사항
  - 홈·채팅·기록·마이페이지: Figma의 24×24 SVG 원본 적용
  - 선 굵기: 1.8pt
  - 아이콘 중심: 55 / 143 / 231 / 319pt
  - 선택 탭은 파란색, 비선택 탭은 회색
  - 탭바 높이와 세로 위치는 변경하지 않음
  - 시뮬레이터 실제 렌더링 확인 완료



## 📷 스크린샷



## 🔗 관련 이슈

close #159 

## 💬 참고사항
없음

