### PR TITLE
fix: [#169] 회원탈퇴 API 경로 및 오류 처리 수정

### DIFF
--- a/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
+++ b/Sources/HopesDesignSystem/Networking/HopesAPIClient.swift
@@ -228,10 +228,11 @@ public actor HopesAPIClient {
 
     public func deleteMyAccount(password: String) async throws {
         try await requestNoContent(
-            path: "/api/users/me",
+            path: "/api/account",
             method: "DELETE",
             body: DeleteAccountRequest(password: password),
-            requiresAuthentication: true
+            requiresAuthentication: true,
+            clearStoredTokenOnUnauthorized: false
         )
         try? await tokenStore.clear()
     }
@@ -316,7 +317,8 @@ public actor HopesAPIClient {
         path: String,
         method: String,
         body: Body,
-        requiresAuthentication: Bool
+        requiresAuthentication: Bool,
+        clearStoredTokenOnUnauthorized: Bool = true
     ) async throws {
         guard let url = URL(string: path, relativeTo: baseURL) else {
             throw HopesAPIError.invalidResponse
@@ -351,7 +353,9 @@ public actor HopesAPIClient {
         guard 200..<300 ~= httpResponse.statusCode else {
             let message = serverMessage(from: data)
             if httpResponse.statusCode == 401 {
-                try? await tokenStore.clear()
+                if clearStoredTokenOnUnauthorized {
+                    try? await tokenStore.clear()
+                }
                 throw HopesAPIError.unauthorized(message)
             }
             throw HopesAPIError.server(statusCode: httpResponse.statusCode, message: message)

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -699,9 +699,9 @@ public struct LoginFlowView: View {
                 }
             } catch {
                 await MainActor.run {
-                    handleAuthenticationFailure(error)
                     isDeletingAccount = false
                     accountDeletionErrorMessage = error.localizedDescription
+                    settingsErrorMessage = "회원탈퇴에 실패했습니다. \(error.localizedDescription)"
                 }
             }
         }


### PR DESCRIPTION
## 📌 변경사항

- 회원탈퇴 요청 경로를 API 명세에 맞게 `DELETE /api/account`로 수정했습니다.
- 비밀번호 불일치(401) 시 저장 토큰을 유지해 탈퇴 실패가 로그아웃으로 오인되지 않도록 했습니다.
- 탈퇴 실패 메시지를 설정 화면에 표시하도록 수정했습니다.

## 📷 스크린샷

- 시뮬레이터에서 회원탈퇴 입력·확인 흐름을 확인했습니다.

## 🔗 관련 이슈

close #169

## 💬 참고사항

- `xcodebuild -workspace Hopes.xcworkspace -scheme Hopes -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` 성공
