### PR TITLE
fix: [#173] 설정 회원탈퇴 진입 연결

### DIFF
--- a/Sources/HopesDesignSystem/Screens/AccountDeletionView.swift
+++ b/Sources/HopesDesignSystem/Screens/AccountDeletionView.swift
@@ -2,23 +2,22 @@ import SwiftUI
 
 public struct AccountDeletionView: View {
     @State private var password = ""
-    @State private var isConfirmationPresented = false
 
     private let isDeleting: Bool
     private let errorMessage: String?
     private let onCancel: () -> Void
-    private let onDelete: (String) -> Void
+    private let onContinue: (String) -> Void
 
     public init(
         isDeleting: Bool = false,
         errorMessage: String? = nil,
         onCancel: @escaping () -> Void = {},
-        onDelete: @escaping (String) -> Void = { _ in }
+        onContinue: @escaping (String) -> Void = { _ in }
     ) {
         self.isDeleting = isDeleting
         self.errorMessage = errorMessage
         self.onCancel = onCancel
-        self.onDelete = onDelete
+        self.onContinue = onContinue
     }
 
     public var body: some View {
@@ -67,23 +66,11 @@ public struct AccountDeletionView: View {
                     variant: .danger,
                     width: .fill,
                     isEnabled: canDelete,
-                    action: { isConfirmationPresented = true }
+                    action: { onContinue(password) }
                 )
             }
         }
         .padding(24)
-        .confirmationDialog(
-            "정말 회원탈퇴 하시겠어요?",
-            isPresented: $isConfirmationPresented,
-            titleVisibility: .visible
-        ) {
-            Button("회원탈퇴", role: .destructive) {
-                onDelete(password)
-            }
-            Button("취소", role: .cancel) {}
-        } message: {
-            Text("계정과 학습 기록은 복구할 수 없습니다.")
-        }
     }
 
     private var canDelete: Bool {

--- a/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
+++ b/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
@@ -68,7 +68,7 @@ public struct AccountInfoView: View {
                 isDeleting: isDeletingAccount,
                 errorMessage: accountDeletionErrorMessage,
                 onCancel: { isDeletionSheetPresented = false },
-                onDelete: onDeleteAccount
+                onContinue: onDeleteAccount
             )
             .presentationDetents([.medium])
             .presentationDragIndicator(.visible)

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -289,6 +289,9 @@ public struct LoginFlowView: View {
                     onLogout: {
                         logout()
                     },
+                    isDeletingAccount: isDeletingAccount,
+                    accountDeletionErrorMessage: accountDeletionErrorMessage,
+                    onDeleteAccount: deleteAccount,
                     onSelectTab: navigateFromTab
                 )
                     .transition(.opacity)

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 public struct SettingsView: View {
     @State private var selectedTab: HopesTab = .settings
+    @State private var isDeletionSheetPresented = false
+    @State private var deletionPasswordAwaitingConfirmation: String?
+    @State private var pendingDeletionPassword: String?
 
     private let contactEmail: String
     private let onBackToChat: () -> Void
@@ -9,6 +12,9 @@ public struct SettingsView: View {
     private let onOpenPersonalSettings: () -> Void
     private let onOpenContact: () -> Void
     private let onLogout: () -> Void
+    private let isDeletingAccount: Bool
+    private let accountDeletionErrorMessage: String?
+    private let onDeleteAccount: (String) -> Void
     private let onSelectTab: (HopesTab) -> Void
     private let isLoggingOut: Bool
     private let errorMessage: String?
@@ -22,6 +28,9 @@ public struct SettingsView: View {
         onOpenPersonalSettings: @escaping () -> Void = {},
         onOpenContact: @escaping () -> Void = {},
         onLogout: @escaping () -> Void = {},
+        isDeletingAccount: Bool = false,
+        accountDeletionErrorMessage: String? = nil,
+        onDeleteAccount: @escaping (String) -> Void = { _ in },
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.contactEmail = contactEmail
@@ -32,6 +41,9 @@ public struct SettingsView: View {
         self.onOpenPersonalSettings = onOpenPersonalSettings
         self.onOpenContact = onOpenContact
         self.onLogout = onLogout
+        self.isDeletingAccount = isDeletingAccount
+        self.accountDeletionErrorMessage = accountDeletionErrorMessage
+        self.onDeleteAccount = onDeleteAccount
         self.onSelectTab = onSelectTab
     }
 
@@ -63,29 +75,59 @@ public struct SettingsView: View {
             .padding(.leading, 37)
             .padding(.top, 217)
 
-            HopesButton(
-                isLoggingOut ? "로그아웃 중..." : "로그아웃",
-                variant: .danger,
-                width: .fixed(330),
-                isEnabled: !isLoggingOut,
-                action: onLogout
-            )
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 29)
-            .padding(.top, 307)
+            accountActions
+                .padding(.horizontal, 29)
+                .padding(.top, 318)
 
             if let errorMessage {
                 Text(errorMessage)
                     .font(.footnote)
                     .foregroundStyle(Color.hopesDanger)
                     .padding(.horizontal, 30)
-                    .padding(.top, 365)
+                    .padding(.top, 490)
             }
 
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
                 .frame(maxHeight: .infinity, alignment: .bottom)
         }
         .ignoresSafeArea()
+        .sheet(isPresented: $isDeletionSheetPresented, onDismiss: {
+            guard let password = deletionPasswordAwaitingConfirmation else { return }
+            pendingDeletionPassword = password
+            deletionPasswordAwaitingConfirmation = nil
+        }) {
+            AccountDeletionView(
+                isDeleting: isDeletingAccount,
+                errorMessage: accountDeletionErrorMessage,
+                onCancel: { isDeletionSheetPresented = false },
+                onContinue: { password in
+                    deletionPasswordAwaitingConfirmation = password
+                    isDeletionSheetPresented = false
+                }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
+            .interactiveDismissDisabled(isDeletingAccount)
+        }
+        .confirmationDialog(
+            "정말 회원탈퇴 하시겠어요?",
+            isPresented: Binding(
+                get: { pendingDeletionPassword != nil },
+                set: { isPresented in
+                    if !isPresented { pendingDeletionPassword = nil }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("회원탈퇴", role: .destructive) {
+                guard let password = pendingDeletionPassword else { return }
+                pendingDeletionPassword = nil
+                onDeleteAccount(password)
+            }
+            Button("취소", role: .cancel) {}
+        } message: {
+            Text("계정과 학습 기록은 복구할 수 없습니다.")
+        }
     }
 
     private var header: some View {
@@ -116,6 +158,68 @@ public struct SettingsView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    private var accountActions: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("계정")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Color.hopesTextSecondary)
+                .padding(.leading, 8)
+
+            VStack(spacing: 0) {
+                accountActionRow(
+                    title: isLoggingOut ? "로그아웃 중..." : "로그아웃",
+                    icon: "rectangle.portrait.and.arrow.right",
+                    isEnabled: !isLoggingOut,
+                    action: onLogout
+                )
+
+                Divider().padding(.leading, 52)
+
+                accountActionRow(
+                    title: "회원탈퇴",
+                    icon: "person.crop.circle.badge.xmark",
+                    action: { isDeletionSheetPresented = true }
+                )
+            }
+            .background(.white)
+            .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius))
+            .overlay {
+                RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
+                    .stroke(Color.hopesBorder, lineWidth: 1)
+            }
+        }
+    }
+
+    private func accountActionRow(
+        title: String,
+        icon: String,
+        isEnabled: Bool = true,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .medium))
+                    .frame(width: 24)
+                Text(title).font(.subheadline.weight(.semibold))
+                Spacer()
+                if isLoggingOut && title == "로그아웃 중..." {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 13, weight: .semibold))
+                }
+            }
+            .foregroundStyle(Color.hopesDanger)
+            .frame(maxWidth: .infinity, minHeight: 56)
+            .padding(.horizontal, 16)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(!isEnabled)
+        .opacity(isEnabled ? 1 : 0.55)
     }
 
 }


### PR DESCRIPTION
## 📌 변경사항

- 설정 화면 로그아웃 아래에 회원탈퇴 버튼을 추가했습니다.
- 버튼에서 기존 비밀번호 입력·최종 확인 시트를 열고, 기존 회원탈퇴 API 호출 로직과 연결했습니다.

## 📷 스크린샷

- iPhone 17 Pro 시뮬레이터 설정 화면에서 로그아웃 아래 회원탈퇴 버튼 표시를 확인했습니다.

## 🔗 관련 이슈

close #173

## 💬 참고사항

- `xcodebuild -workspace Hopes.xcworkspace -scheme Hopes -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` 성공
