### PR TITLE
fix: [#175] Xcode Cloud 플랫폼 빌드 오류 해결

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,6 @@ let package = Package(
     name: "HopesDesignSystem",
     platforms: [
         .iOS(.v17),
-        .macOS(.v14),
     ],
     products: [
         .library(


### PR DESCRIPTION
## 📌 변경사항

- iOS 전용 디자인 시스템 패키지의 macOS 지원 선언을 제거했습니다.
- Xcode Cloud가 iOS 외 플랫폼에서 UIKit을 빌드하며 실패하는 오류를 방지했습니다.

## 📷 스크린샷

- 해당 없음

## 🔗 관련 이슈

close #175

## 💬 참고사항

- 로컬 `swift build`에서 `ChatHomeView.swift: no such module UIKit` 오류를 재현했습니다.
- 수정 후 `xcodebuild -workspace Hopes.xcworkspace -scheme Hopes -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` 성공
