### PR TITLE
fix: [#178] 설정 회원탈퇴 Cloud 참조 오류 해결

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -96,7 +96,7 @@ public struct SettingsView: View {
             pendingDeletionPassword = password
             deletionPasswordAwaitingConfirmation = nil
         }) {
-            AccountDeletionView(
+            SettingsAccountDeletionView(
                 isDeleting: isDeletingAccount,
                 errorMessage: accountDeletionErrorMessage,
                 onCancel: { isDeletionSheetPresented = false },
@@ -227,4 +227,66 @@ public struct SettingsView: View {
 #Preview("설정") {
     SettingsView()
         .frame(width: 402, height: 874)
+}
+
+private struct SettingsAccountDeletionView: View {
+    @State private var password = ""
+
+    let isDeleting: Bool
+    let errorMessage: String?
+    let onCancel: () -> Void
+    let onContinue: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("회원탈퇴")
+                .font(.title2.weight(.bold))
+                .foregroundStyle(Color.hopesTextPrimary)
+
+            Text("탈퇴하면 계정과 학습 기록을 복구할 수 없어요.")
+                .font(.subheadline)
+                .foregroundStyle(Color.hopesTextSecondary)
+                .padding(.top, 8)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("계정을 삭제하려면 현재 비밀번호를 입력해 주세요.")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundStyle(Color.hopesDanger)
+
+                SecureField("현재 비밀번호", text: $password)
+                    .textContentType(.password)
+                    .font(.subheadline)
+                    .padding(.horizontal, 16)
+                    .frame(height: HopesMetrics.textFieldHeight)
+                    .background(Color.hopesInputBackground)
+                    .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)
+                            .stroke(Color.hopesBorder, lineWidth: 1)
+                    }
+            }
+            .padding(.top, 28)
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.footnote)
+                    .foregroundStyle(Color.hopesDanger)
+                    .padding(.top, 12)
+            }
+
+            Spacer(minLength: 24)
+
+            HStack(spacing: 12) {
+                HopesButton("취소", variant: .secondary, width: .fill, isEnabled: !isDeleting, action: onCancel)
+                HopesButton(
+                    isDeleting ? "탈퇴 처리 중..." : "회원탈퇴",
+                    variant: .danger,
+                    width: .fill,
+                    isEnabled: password.count >= 8 && !isDeleting,
+                    action: { onContinue(password) }
+                )
+            }
+        }
+        .padding(24)
+    }
 }


### PR DESCRIPTION
## 변경사항
- Xcode Cloud의 파일 단위 컴파일에서 SettingsView가 회원탈퇴 시트를 찾지 못하던 오류를 해결했습니다.
- 회원탈퇴 시트 선언을 SettingsView 내부 파일로 한정했습니다.

## 영향 범위
- 설정 UI, 비밀번호 입력, 최종 확인 팝업, 회원탈퇴 API 호출 흐름은 변경하지 않습니다.

## 검증
- `xcodebuild -workspace Hopes.xcworkspace -scheme Hopes -sdk iphonesimulator -destination "generic/platform=iOS Simulator" build` 성공

Closes #178