### PR TITLE
Fix 페이지 코드 리팩터링 작업

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -46,27 +46,19 @@ public struct HopesTabBar: View {
     }
 
     public var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .top) {
-                Color.white
-
-                HStack(spacing: 0) {
-                    ForEach(HopesTab.allCases, id: \.self) { tab in
-                        tabButton(tab)
-                            .frame(maxWidth: .infinity)
-                    }
-                }
-                .frame(width: geometry.size.width, height: 84, alignment: .top)
-            }
-            .frame(width: geometry.size.width, height: 84, alignment: .top)
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.hopesBorder)
-                    .frame(height: 1)
+        HStack(spacing: 0) {
+            ForEach(HopesTab.allCases, id: \.self) { tab in
+                tabButton(tab)
+                    .frame(maxWidth: .infinity)
             }
         }
-        .frame(maxWidth: .infinity)
-        .frame(height: 84, alignment: .top)
+        .frame(height: 84)
+        .background(.white)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.hopesBorder)
+                .frame(height: 1)
+        }
         .ignoresSafeArea(.container, edges: .bottom)
     }
 
@@ -75,7 +67,7 @@ public struct HopesTabBar: View {
             selection = tab
             onSelect(tab)
         } label: {
-            ZStack(alignment: .top) {
+            VStack(spacing: 4) {
                 Image(tab.iconName)
                     .resizable()
                     .renderingMode(.template)
@@ -86,7 +78,6 @@ public struct HopesTabBar: View {
                             : Color.hopesTextPlaceholder
                     )
                     .frame(width: 24, height: 24)
-                    .position(x: 30, y: 24)
 
                 Text(tab.title)
                     .font(.system(size: 10, weight: .semibold))
@@ -95,13 +86,11 @@ public struct HopesTabBar: View {
                             ? Color(red: 13 / 255, green: 138 / 255, blue: 229 / 255)
                             : Color.hopesTextSecondary
                     )
-                    .frame(width: 46, height: 12, alignment: .center)
-                    .position(x: 30, y: 47)
+                    .lineLimit(1)
             }
-            .frame(width: 60, height: 84, alignment: .top)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
             .contentShape(Rectangle())
         }
-        .frame(width: 60, height: 84, alignment: .top)
         .buttonStyle(.plain)
         .accessibilityLabel(tab.title)
         .accessibilityAddTraits(selection == tab ? .isSelected : [])

--- a/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
+++ b/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
@@ -40,29 +40,30 @@ public struct AccountInfoView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 72)
+                accountCard
+                    .padding(.top, 32)
 
-            accountCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 156)
-
-            HopesButton(
-                "회원탈퇴",
-                variant: .danger,
-                width: .fixed(330),
-                action: { isDeletionSheetPresented = true }
-            )
-            .padding(.top, 470)
-
-            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                .frame(maxHeight: .infinity, alignment: .bottom)
+                HopesButton(
+                    "회원탈퇴",
+                    variant: .danger,
+                    width: .fill,
+                    action: { isDeletionSheetPresented = true }
+                )
+                .padding(.top, 30)
+            }
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.bottom, 24)
         }
-        .ignoresSafeArea()
+        .scrollIndicators(.hidden)
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+        }
         .sheet(isPresented: $isDeletionSheetPresented) {
             AccountDeletionView(
                 isDeleting: isDeletingAccount,
@@ -138,7 +139,6 @@ public struct AccountInfoView: View {
             .foregroundStyle(Color.hopesTextPrimary)
             .padding(.top, 4)
         }
-        .frame(height: 284)
     }
 
 }

--- a/Sources/HopesDesignSystem/Screens/AnswerEvidenceView.swift
+++ b/Sources/HopesDesignSystem/Screens/AnswerEvidenceView.swift
@@ -43,33 +43,32 @@ public struct AnswerEvidenceView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 72)
+                summaryCard
+                    .padding(.top, 32)
 
-            summaryCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 156)
+                evidenceList
+                    .padding(.top, 28)
 
-            evidenceList
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 390)
-
-            HopesButton(
-                "이 근거로 더 물어보기",
-                size: .large,
-                action: onAskMore
-            )
+                HopesButton(
+                    "이 근거로 더 물어보기",
+                    size: .large,
+                    action: onAskMore
+                )
+                .padding(.top, 28)
+            }
             .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-            .padding(.top, 684)
-
-            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                .frame(maxHeight: .infinity, alignment: .bottom)
+            .padding(.bottom, 24)
         }
-        .ignoresSafeArea()
+        .scrollIndicators(.hidden)
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+        }
     }
 
     private var header: some View {
@@ -141,7 +140,6 @@ public struct AnswerEvidenceView: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 24)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 190)
         .background(.white)
         .clipShape(
             RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)

--- a/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
@@ -48,38 +48,34 @@ public struct ChatDetailView: View {
     }
 
     public var body: some View {
-        GeometryReader { geometry in
-            ZStack(alignment: .top) {
-                Color.hopesBackground
-                    .contentShape(Rectangle())
-                    .onTapGesture { isReplyFocused = false }
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+                .padding(.top, 16)
+                .padding(.bottom, 20)
+                .simultaneousGesture(
+                    TapGesture().onEnded { isReplyFocused = false }
+                )
 
-                header
-                    .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                    .padding(.top, 72)
-                    .simultaneousGesture(
-                        TapGesture().onEnded { isReplyFocused = false }
-                    )
+            messageList
+        }
+        .background(Color.hopesBackground.ignoresSafeArea())
+        // 키보드가 표시되면 시스템 Safe Area가 작성 영역을 자동으로 위로 밀어 올립니다.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            VStack(spacing: 0) {
+                composer
 
-                messageList
-                    .padding(.top, 132)
-                    .padding(.bottom, isReplyFocused ? 74 : 158)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            .background(Color.hopesBackground.ignoresSafeArea())
-            .overlay(alignment: .bottom) {
-                VStack(spacing: 0) {
-                    composer
-
-                    if !isReplyFocused {
-                        HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+                if !isReplyFocused {
+                    HopesTabBar(selection: $selectedTab) { tab in
+                        isReplyFocused = false
+                        onSelectTab(tab)
                     }
                 }
-                .frame(maxWidth: .infinity)
-                .offset(y: isReplyFocused ? 0 : geometry.safeAreaInsets.bottom)
             }
+            .background(Color.hopesBackground)
         }
-        .ignoresSafeArea(.container, edges: [.top, .bottom])
+        .contentShape(Rectangle())
+        .onTapGesture { isReplyFocused = false }
     }
 
     private var header: some View {

--- a/Sources/HopesDesignSystem/Screens/ContactView.swift
+++ b/Sources/HopesDesignSystem/Screens/ContactView.swift
@@ -42,30 +42,33 @@ public struct ContactView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
-                .contentShape(Rectangle())
-                .onTapGesture { focusedField = nil }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 72)
+                contactCard
+                    .padding(.top, 32)
 
-            contactCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 156)
-
-            mailInformation
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 624)
-
+                mailInformation
+                    .padding(.top, 20)
+            }
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .simultaneousGesture(
+            TapGesture().onEnded { focusedField = nil },
+            including: .gesture
+        )
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             HopesTabBar(selection: $selectedTab) { tab in
                 focusedField = nil
                 onSelectTab(tab)
             }
-                .frame(maxHeight: .infinity, alignment: .bottom)
         }
-        .ignoresSafeArea()
     }
 
     private var header: some View {
@@ -148,7 +151,6 @@ public struct ContactView: View {
             }
             .padding(.top, 16)
         }
-        .frame(height: 420)
     }
 
     private var emailField: some View {

--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -49,39 +49,44 @@ public struct ConversationHistoryView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
-                .contentShape(Rectangle())
-                .onTapGesture { isSearchFocused = false }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 76)
+                HopesButton(
+                    "+  새 대화 시작",
+                    variant: .secondary,
+                    size: .large,
+                    action: {
+                        isSearchFocused = false
+                        onNewConversation()
+                    }
+                )
+                .padding(.top, 24)
 
-            HopesButton(
-                "+  새 대화 시작",
-                variant: .secondary,
-                size: .large,
-                action: {
-                    isSearchFocused = false
-                    onNewConversation()
-                }
-            )
+                searchBar
+                    .padding(.top, 16)
+
+                conversationList
+                    .padding(.top, 20)
+            }
             .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-            .padding(.top, 144)
-
-            searchBar
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 208)
-
-            conversationList
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 257)
-
-            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                .frame(maxHeight: .infinity, alignment: .bottom)
+            .padding(.bottom, 24)
         }
-        .ignoresSafeArea()
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .simultaneousGesture(
+            TapGesture().onEnded { isSearchFocused = false },
+            including: .gesture
+        )
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HopesTabBar(selection: $selectedTab) { tab in
+                isSearchFocused = false
+                onSelectTab(tab)
+            }
+        }
     }
 
     private var header: some View {
@@ -127,8 +132,7 @@ public struct ConversationHistoryView: View {
     }
 
     private var conversationList: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
+        LazyVStack(alignment: .leading, spacing: 0) {
                 if isLoading {
                     ProgressView("대화 목록을 불러오는 중...")
                         .frame(maxWidth: .infinity)
@@ -151,14 +155,7 @@ public struct ConversationHistoryView: View {
                     title: "모든 기록",
                     conversations: filteredConversations
                 )
-            }
         }
-        .scrollIndicators(.hidden)
-        .scrollDismissesKeyboard(.interactively)
-        .simultaneousGesture(
-            TapGesture().onEnded { isSearchFocused = false }
-        )
-        .frame(height: 420)
     }
 
     private func conversationSection(

--- a/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/GeneralSettingsView.swift
@@ -21,25 +21,25 @@ public struct GeneralSettingsView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 72)
+                generalCard
+                    .padding(.top, 32)
 
-            generalCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 158)
-
-            actionButtons
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 688)
-
-            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                .frame(maxHeight: .infinity, alignment: .bottom)
+                actionButtons
+                    .padding(.top, 32)
+            }
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.bottom, 24)
         }
-        .ignoresSafeArea()
+        .scrollIndicators(.hidden)
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+        }
     }
 
     private var header: some View {
@@ -94,7 +94,6 @@ public struct GeneralSettingsView: View {
                     .padding(.top, 28)
             }
         }
-        .frame(height: 180)
     }
 
     private var backToChatRow: some View {
@@ -135,7 +134,7 @@ public struct GeneralSettingsView: View {
             HopesButton(
                 "완료",
                 size: .regular,
-                width: .fixed(170),
+                width: .fill,
                 action: onDone
             )
 
@@ -143,7 +142,7 @@ public struct GeneralSettingsView: View {
                 "뒤로",
                 variant: .secondary,
                 size: .regular,
-                width: .fixed(170),
+                width: .fill,
                 action: onBack
             )
         }

--- a/Sources/HopesDesignSystem/Screens/LoginView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginView.swift
@@ -7,25 +7,9 @@ public struct LoginView: View {
         case password
     }
 
-    private struct FieldFramePreferenceKey: PreferenceKey {
-        static let defaultValue: [LoginField: CGRect] = [:]
-
-        static func reduce(
-            value: inout [LoginField: CGRect],
-            nextValue: () -> [LoginField: CGRect]
-        ) {
-            value.merge(nextValue(), uniquingKeysWith: { $1 })
-        }
-    }
-
     @State private var isPasswordVisible = false
     @State private var sheetProgress: CGFloat
     @State private var sheetDragStartProgress: CGFloat?
-    @State private var keyboardShift: CGFloat = 0
-    @State private var keyboardFrame: CGRect = .zero
-    @State private var fieldFrames: [LoginField: CGRect] = [:]
-    @State private var maximumKeyboardShift: CGFloat = 0
-    @State private var keyboardAnimationDuration: TimeInterval = 0.25
     @Binding private var email: String
     @Binding private var password: String
     @FocusState private var focusedField: LoginField?
@@ -62,26 +46,18 @@ public struct LoginView: View {
             let collapsedSheetRevealHeight = min(150, geometry.size.height)
             let collapsedOffset = max(0, 502 - collapsedSheetRevealHeight)
             let sheetOffset = collapsedOffset * (1 - sheetProgress)
-            let expandedSheetTop = max(0, geometry.size.height - 502)
-            let maximumShiftForSheet = expandedSheetTop * 0.5
             // Designed-for-iPhone compatibility can expose a shorter effective
             // height than a full iPhone screen. Preserve the Figma spacing on
             // regular heights, but make room between the hero copy and cue on
             // compact heights.
             let heroTopPadding = min(168, max(80, geometry.size.height - 615))
             let swipeCueBottomPadding: CGFloat = geometry.size.height < 800 ? 150 : 190
-            let keyboardTop = keyboardFrame.height > 0
-                ? keyboardFrame.minY
-                : geometry.size.height
-            let heroBackgroundHeight = keyboardTop
-            let currentSheetOffset = sheetOffset - keyboardShift
 
             ZStack(alignment: .bottom) {
                 Color.white
                     .ignoresSafeArea()
 
                 Color.hopesHeroGradient
-                    .frame(height: heroBackgroundHeight)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                     .ignoresSafeArea(edges: .top)
 
@@ -108,115 +84,18 @@ public struct LoginView: View {
                     .blur(radius: 5 * sheetProgress)
                     .allowsHitTesting(false)
 
-                loginSheet(maximumKeyboardShift: maximumShiftForSheet)
-                    .offset(y: currentSheetOffset)
+                loginSheet()
+                    .offset(y: sheetOffset)
                     .simultaneousGesture(sheetDragGesture(collapsedOffset: collapsedOffset))
-
-                // When the sheet moves up for the keyboard, its fixed 502pt
-                // content no longer reaches the physical bottom of the app
-                // window. Keep the same white sheet surface continuous down
-                // to that edge so the hero gradient cannot appear between the
-                // sheet and the translucent keyboard corners.
-                Color.white
-                    .frame(height: max(0, -currentSheetOffset))
-                    .frame(maxWidth: .infinity)
-                    .ignoresSafeArea(.keyboard, edges: .bottom)
-                    .allowsHitTesting(false)
-                    .zIndex(9)
-
-                // The keyboard's rounded bottom area is translucent in the
-                // simulator. Cover exactly the keyboard region in the app
-                // window so the hero gradient cannot show through it.
-                Color.white
-                    .frame(
-                        height: keyboardFrame.height > 0
-                            ? max(0, geometry.size.height - keyboardTop)
-                            : 0
-                    )
-                    .frame(maxWidth: .infinity)
-                    .ignoresSafeArea(.keyboard, edges: .bottom)
-                    .allowsHitTesting(false)
-                    .zIndex(10)
-            }
-            .onAppear {
-                maximumKeyboardShift = maximumShiftForSheet
-            }
-            .onChange(of: geometry.size.height) { _, height in
-                maximumKeyboardShift = max(0, height - 502) * 0.5
             }
         }
         .ignoresSafeArea(.container, edges: [.top, .bottom])
-        // Keep the fixed Figma sheet geometry stable while the keyboard is
-        // visible. Keyboard avoidance is handled explicitly below from the
-        // focused field's frame, rather than by shrinking this GeometryReader.
-        .ignoresSafeArea(.keyboard)
         .preferredColorScheme(.light)
         .onAppear {
             Task { @MainActor in
                 await Task.yield()
                 applyLightKeyboardAppearanceToInputs()
             }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillChangeFrameNotification)) { notification in
-            guard let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect else {
-                return
-            }
-
-            keyboardFrame = frame
-            keyboardAnimationDuration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0.25
-            Task { @MainActor in
-                // Let the focused field's global frame settle after the keyboard layout pass.
-                await Task.yield()
-                applyLightKeyboardAppearanceToInputs()
-                updateKeyboardShift(
-                    using: frame,
-                    maximumShift: maximumKeyboardShift,
-                    animated: true
-                )
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardWillHideNotification)) { notification in
-            keyboardFrame = .zero
-            keyboardAnimationDuration = notification.userInfo?[UIResponder.keyboardAnimationDurationUserInfoKey] as? TimeInterval ?? 0.25
-
-            withAnimation(.easeInOut(duration: keyboardAnimationDuration)) {
-                keyboardShift = 0
-            }
-        }
-    }
-
-    private func updateKeyboardShift(
-        using frame: CGRect,
-        maximumShift: CGFloat,
-        animated: Bool
-    ) {
-        guard frame.height > 0,
-              focusedField != nil,
-              let emailFrame = fieldFrames[.email],
-              let passwordFrame = fieldFrames[.password] else {
-            return
-        }
-
-        // The measured frame already includes the current keyboard translation.
-        // Add it back so changing focus does not accumulate or lose the sheet shift.
-        // The notification frame is in screen coordinates while the SwiftUI
-        // global frame is in the app window's coordinate space. Convert the
-        // keyboard frame before comparing the two. Keep both input fields
-        // visible; controls below them are intentionally allowed to remain
-        // behind the keyboard.
-        let keyboardFrameInWindow = keyboardFrameInWindow(frame)
-        let unshiftedInputBottom = max(emailFrame.maxY, passwordFrame.maxY) + keyboardShift
-        let requiredShift = min(
-            maximumShift,
-            max(0, unshiftedInputBottom + 14 - keyboardFrameInWindow.minY)
-        )
-
-        if animated {
-            withAnimation(.easeInOut(duration: keyboardAnimationDuration)) {
-                keyboardShift = requiredShift
-            }
-        } else {
-            keyboardShift = requiredShift
         }
     }
 
@@ -253,20 +132,6 @@ public struct LoginView: View {
         }
     }
 
-    private func keyboardFrameInWindow(_ frame: CGRect) -> CGRect {
-        #if os(iOS)
-        guard let window = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .flatMap(\.windows)
-            .first(where: { $0.isKeyWindow }) else {
-            return frame
-        }
-
-        return window.convert(frame, from: window.screen.coordinateSpace)
-        #else
-        return frame
-        #endif
-    }
 
     private var hero: some View {
         VStack(alignment: .leading, spacing: 13) {
@@ -347,34 +212,13 @@ public struct LoginView: View {
             }
     }
 
-    private func loginSheet(maximumKeyboardShift: CGFloat) -> some View {
-        GeometryReader { geometry in
-            ScrollView(.vertical, showsIndicators: false) {
-                loginSheetContent
-                    .frame(minHeight: 502, alignment: .top)
-            }
-            .scrollIndicators(.hidden)
-            .onPreferenceChange(FieldFramePreferenceKey.self) { frames in
-                fieldFrames = frames
-            }
-            .onChange(of: focusedField) { _, field in
-                if field == nil {
-                    withAnimation(.easeInOut(duration: keyboardAnimationDuration)) {
-                        keyboardShift = 0
-                    }
-                } else if keyboardFrame.height > 0 {
-                    Task { @MainActor in
-                        await Task.yield()
-                        applyLightKeyboardAppearanceToInputs()
-                        updateKeyboardShift(
-                            using: keyboardFrame,
-                            maximumShift: maximumKeyboardShift,
-                            animated: true
-                        )
-                    }
-                }
-            }
+    private func loginSheet() -> some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            loginSheetContent
+                .frame(minHeight: 502, alignment: .top)
         }
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
         .frame(height: 502)
         .background(.white)
         .clipShape(
@@ -425,14 +269,6 @@ public struct LoginView: View {
                         RoundedRectangle(cornerRadius: 14)
                             .stroke(Color(red: 217 / 255, green: 217 / 255, blue: 217 / 255), lineWidth: 1)
                     }
-                    .background {
-                        GeometryReader { geometry in
-                            Color.clear.preference(
-                                key: FieldFramePreferenceKey.self,
-                                value: [.email: geometry.frame(in: .global)]
-                            )
-                        }
-                    }
                     .padding(.top, 7)
                     .accessibilityLabel("이메일")
                     .id(LoginField.email)
@@ -475,14 +311,6 @@ public struct LoginView: View {
                         }
                         .buttonStyle(.plain)
                         .accessibilityLabel(isPasswordVisible ? "비밀번호 숨기기" : "비밀번호 보기")
-                    }
-                    .background {
-                        GeometryReader { geometry in
-                            Color.clear.preference(
-                                key: FieldFramePreferenceKey.self,
-                                value: [.password: geometry.frame(in: .global)]
-                            )
-                        }
                     }
                     .padding(.top, 9)
                     .accessibilityLabel("비밀번호")

--- a/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
+++ b/Sources/HopesDesignSystem/Screens/PasswordResetView.swift
@@ -48,12 +48,7 @@ public struct PasswordResetView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .topLeading) {
-            Color.hopesBackground
-                .ignoresSafeArea()
-                .contentShape(Rectangle())
-                .onTapGesture { focusedField = nil }
-
+        ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 Button {
                     focusedField = nil
@@ -154,18 +149,23 @@ public struct PasswordResetView: View {
                         }
                     }
 
-                Spacer()
-
                 HopesButton("완료", size: .large, isEnabled: canComplete) {
                     focusedField = nil
                     onComplete()
                 }
+                .padding(.top, 36)
             }
             .padding(.horizontal, 28)
             .padding(.top, 24)
             .padding(.bottom, 34)
         }
-        .ignoresSafeArea(.keyboard, edges: .bottom)
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .simultaneousGesture(
+            TapGesture().onEnded { focusedField = nil },
+            including: .gesture
+        )
+        .background(Color.hopesBackground.ignoresSafeArea())
         .onChange(of: codeRequested) { _, requested in
             if requested {
                 focusedField = .code

--- a/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
@@ -41,26 +41,30 @@ public struct PersonalSettingsView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
-                .contentShape(Rectangle())
-                .onTapGesture { focusedField = nil }
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 72)
-
-            promptCard
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 158)
-
+                promptCard
+                    .padding(.top, 32)
+            }
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .scrollDismissesKeyboard(.interactively)
+        .simultaneousGesture(
+            TapGesture().onEnded { focusedField = nil },
+            including: .gesture
+        )
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
             HopesTabBar(selection: $selectedTab) { tab in
                 focusedField = nil
                 onSelectTab(tab)
             }
-                .frame(maxHeight: .infinity, alignment: .bottom)
         }
-        .ignoresSafeArea()
     }
 
     private var header: some View {
@@ -141,7 +145,6 @@ public struct PersonalSettingsView: View {
                 }
             }
         }
-        .frame(height: 408)
     }
 
     private var promptEditor: some View {

--- a/Sources/HopesDesignSystem/Screens/SettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/SettingsView.swift
@@ -48,49 +48,43 @@ public struct SettingsView: View {
     }
 
     public var body: some View {
-        ZStack(alignment: .top) {
-            Color.hopesBackground
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                header
+                    .padding(.top, 24)
 
-            header
-                .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
-                .padding(.top, 76)
+                HopesActionRow(
+                    title: "개인 설정",
+                    subtitle: "시스템 프롬프트 관리",
+                    action: onOpenPersonalSettings
+                )
+                .padding(.top, 34)
 
-            HopesActionRow(
-                title: "개인 설정",
-                subtitle: "시스템 프롬프트 관리",
-                action: onOpenPersonalSettings
-            )
-            .frame(width: 314)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 37)
-            .padding(.top, 150)
+                HopesActionRow(
+                    title: "문의하기",
+                    subtitle: contactEmail,
+                    action: onOpenContact
+                )
+                .padding(.top, 12)
 
-            HopesActionRow(
-                title: "문의하기",
-                subtitle: contactEmail,
-                action: onOpenContact
-            )
-            .frame(width: 314)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.leading, 37)
-            .padding(.top, 217)
+                accountActions
+                    .padding(.top, 32)
 
-            accountActions
-                .padding(.horizontal, 29)
-                .padding(.top, 318)
-
-            if let errorMessage {
-                Text(errorMessage)
-                    .font(.footnote)
-                    .foregroundStyle(Color.hopesDanger)
-                    .padding(.horizontal, 30)
-                    .padding(.top, 490)
+                if let errorMessage {
+                    Text(errorMessage)
+                        .font(.footnote)
+                        .foregroundStyle(Color.hopesDanger)
+                        .padding(.top, 18)
+                }
             }
-
-            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-                .frame(maxHeight: .infinity, alignment: .bottom)
+            .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
+            .padding(.bottom, 24)
         }
-        .ignoresSafeArea()
+        .scrollIndicators(.hidden)
+        .background(Color.hopesBackground.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
+        }
         .sheet(isPresented: $isDeletionSheetPresented, onDismiss: {
             guard let password = deletionPasswordAwaitingConfirmation else { return }
             pendingDeletionPassword = password


### PR DESCRIPTION
## 📌 변경사항
각 화면의 큰 ZStack + 고정 top padding 배치를 VStack·ScrollView·safeAreaInset 중심으로 바꿈
키보드 내리기 처리도 추가
무거운 코드들을 가볍게 리팩터링 했습니다 
기존 키보드 뷰를 실행할때 계산 로직을 지우고 scrollDismissesKeyboard(.interactively) 추가 및 ignoresSafeArea(.keyboard) 제거
배포시에 문제될만한 코드 삭제 및 흐름에 따라서 필요한 주석 처리 
## 📷 스크린샷



## 🔗 관련 이슈

close #185 

## 💬 참고사항
그다음 이슈때 네트워크 코드 분리 예정

