### PR TITLE
Fix 비밀번호 정규식 오류 표시

### DIFF
--- a/Sources/HopesDesignSystem/Screens/SignUpView.swift
+++ b/Sources/HopesDesignSystem/Screens/SignUpView.swift
@@ -159,7 +159,8 @@ public struct SignUpView: View {
                     placeholder: "영문·숫자 포함 8~15자",
                     kind: .password,
                     isPasswordVisible: $isPasswordVisible,
-                    focus: .password
+                    focus: .password,
+                    validationMessage: passwordValidationMessage
                 )
                 signUpField(
                     "비밀번호 확인",
@@ -167,7 +168,8 @@ public struct SignUpView: View {
                     placeholder: "비밀번호 재입력",
                     kind: .password,
                     isPasswordVisible: $isPasswordConfirmVisible,
-                    focus: .passwordConfirm
+                    focus: .passwordConfirm,
+                    validationMessage: passwordConfirmValidationMessage
                 )
             }
             .padding(.horizontal, 16)
@@ -228,7 +230,8 @@ public struct SignUpView: View {
         placeholder: String,
         kind: SignUpFieldKind = .plain,
         isPasswordVisible: Binding<Bool>? = nil,
-        focus: SignUpField? = nil
+        focus: SignUpField? = nil,
+        validationMessage: String? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 7) {
             Text(title)
@@ -294,10 +297,16 @@ public struct SignUpView: View {
             .clipShape(RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius))
             .overlay {
                 RoundedRectangle(cornerRadius: HopesMetrics.controlCornerRadius)
-                    .stroke(Color.hopesBorder, lineWidth: 1)
+                    .stroke(validationMessage == nil ? Color.hopesBorder : Color.hopesDanger, lineWidth: 1)
+            }
+
+            if let validationMessage {
+                Text(validationMessage)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(Color.hopesDanger)
             }
         }
-        .frame(height: 76, alignment: .top)
+        .frame(height: validationMessage == nil ? 76 : 94, alignment: .top)
     }
 
     private var signUpButton: some View {
@@ -350,6 +359,18 @@ public struct SignUpView: View {
 
     private var isVerificationCodeValid: Bool {
         verificationCode.range(of: #"^\d{6}$"#, options: .regularExpression) != nil
+    }
+
+    private var passwordValidationMessage: String? {
+        guard !password.isEmpty, !PasswordPolicy.isValid(password) else { return nil }
+        return "영문과 숫자를 포함한 8~15자로 입력해주세요."
+    }
+
+    private var passwordConfirmValidationMessage: String? {
+        guard !passwordConfirm.isEmpty, PasswordPolicy.isValid(password), password != passwordConfirm else {
+            return nil
+        }
+        return "비밀번호가 일치하지 않습니다."
     }
 
     private var isFormValid: Bool {


### PR DESCRIPTION
## 📌 변경사항
- 비밀번호가 영문·숫자 포함 8~15자 정규식을 만족하지 않으면 즉시 오류 문구 표시
- 비밀번호 확인값이 일치하지 않으면 별도 오류 문구 표시
- 오류 상태 입력 필드 테두리를 위험 색상으로 표시

## 📷 스크린샷
- 실제 시뮬레이터 화면 검사는 요청에 따라 사용자 검토로 진행합니다.

## 🔗 관련 이슈
close #191

## 💬 참고사항
- 기존 회원가입 버튼 활성화 조건은 유지했습니다.