### PR TITLE
Fix 탭바 하단 Safe Area 여백 수정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -53,7 +53,7 @@ public struct HopesTabBar: View {
             }
         }
         .frame(height: 84)
-        .background(.white)
+        .background(Color.white.ignoresSafeArea(edges: .bottom))
         .overlay(alignment: .top) {
             Rectangle()
                 .fill(Color.hopesBorder)


### PR DESCRIPTION
## 📌 변경사항
- 공통 탭바의 흰 배경을 기기 하단 Safe Area까지 확장
- 탭바 아래에 화면 배경색이 노출되지 않도록 수정

## 📷 스크린샷
- 기기별 Safe Area 확인이 필요한 레이아웃 변경입니다.

## 🔗 관련 이슈
close #193

## 💬 참고사항
- 공통 HopesTabBar에서 처리해 탭바를 사용하는 모든 화면에 적용됩니다.