### PR TITLE
Fix 탭바 하단 Safe Area 높이 수정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -53,13 +53,12 @@ public struct HopesTabBar: View {
             }
         }
         .frame(height: 84)
-        .background(Color.white.ignoresSafeArea(edges: .bottom))
+        .background(.white)
         .overlay(alignment: .top) {
             Rectangle()
                 .fill(Color.hopesBorder)
                 .frame(height: 1)
         }
-        .ignoresSafeArea(.container, edges: .bottom)
     }
 
     private func tabButton(_ tab: HopesTab) -> some View {


### PR DESCRIPTION
## 📌 변경사항
- 탭바 배경의 하단 Safe Area 강제 확장을 제거
- 탭바가 실제 기기에서 과도하게 위로 커지지 않도록 수정

## 📷 스크린샷
- iPhone 시뮬레이터 온보딩 화면에서 하단 고정 위치를 확인했습니다.

## 🔗 관련 이슈
close #195

## 💬 참고사항
- 탭바 높이는 84pt로 유지하고, 키보드 레이아웃에 영향을 주는 전역 Safe Area 무시를 제거했습니다.