### PR TITLE
Fix 탭바와 하단 Safe Area 영역 분리

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -46,19 +46,23 @@ public struct HopesTabBar: View {
     }
 
     public var body: some View {
-        HStack(spacing: 0) {
-            ForEach(HopesTab.allCases, id: \.self) { tab in
-                tabButton(tab)
-                    .frame(maxWidth: .infinity)
+        GeometryReader { geometry in
+            HStack(spacing: 0) {
+                ForEach(HopesTab.allCases, id: \.self) { tab in
+                    tabButton(tab)
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .frame(height: max(0, 84 - geometry.safeAreaInsets.bottom))
+            .frame(maxWidth: .infinity, alignment: .top)
+            .background(.white)
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(Color.hopesBorder)
+                    .frame(height: 1)
             }
         }
         .frame(height: 84)
-        .background(.white)
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(Color.hopesBorder)
-                .frame(height: 1)
-        }
     }
 
     private func tabButton(_ tab: HopesTab) -> some View {


### PR DESCRIPTION
## 📌 변경사항
- 탭바 높이 안에서 하단 Safe Area만큼을 투명 영역으로 분리
- 탭바는 흰색으로 고정하고, 기기 하단 Safe Area에는 화면 배경색이 표시되도록 수정

## 📷 스크린샷
- iPhone 시뮬레이터 온보딩 화면에서 피그마와 같은 하단 Safe Area 분리를 확인했습니다.

## 🔗 관련 이슈
close #197

## 💬 참고사항
- 기기별 Safe Area inset을 사용해 하단 여백을 동적으로 처리합니다.