### PR TITLE
Fix 초기 화면 레이아웃 및 Safe Area 조정

### DIFF
--- a/Sources/HopesDesignSystem/Components/HopesTabBar.swift
+++ b/Sources/HopesDesignSystem/Components/HopesTabBar.swift
@@ -34,6 +34,7 @@ public enum HopesTab: String, CaseIterable, Sendable {
 }
 
 public struct HopesTabBar: View {
+    private let contentHeight: CGFloat = 56
     @Binding private var selection: HopesTab
     private let onSelect: (HopesTab) -> Void
 
@@ -46,23 +47,20 @@ public struct HopesTabBar: View {
     }
 
     public var body: some View {
-        GeometryReader { geometry in
-            HStack(spacing: 0) {
-                ForEach(HopesTab.allCases, id: \.self) { tab in
-                    tabButton(tab)
-                        .frame(maxWidth: .infinity)
-                }
-            }
-            .frame(height: max(0, 84 - geometry.safeAreaInsets.bottom))
-            .frame(maxWidth: .infinity, alignment: .top)
-            .background(.white)
-            .overlay(alignment: .top) {
-                Rectangle()
-                    .fill(Color.hopesBorder)
-                    .frame(height: 1)
+        HStack(spacing: 0) {
+            ForEach(HopesTab.allCases, id: \.self) { tab in
+                tabButton(tab)
+                    .frame(maxWidth: .infinity)
             }
         }
-        .frame(height: 84)
+        .frame(height: contentHeight)
+        .frame(maxWidth: .infinity)
+        .background(.white)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(Color.hopesBorder)
+                .frame(height: 1)
+        }
     }
 
     private func tabButton(_ tab: HopesTab) -> some View {

--- a/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatHomeView.swift
@@ -74,13 +74,13 @@ public struct ChatHomeView: View {
         VStack(spacing: 0) {
             header
                 .padding(.horizontal, 24)
-                .padding(.top, 72)
+                .padding(.top, 16)
                 .simultaneousGesture(
                     TapGesture().onEnded { isInputFocused = false }
                 )
 
             HopesLogo(size: .large)
-                .padding(.top, 74)
+                .padding(.top, 54)
                 .contentShape(Rectangle())
                 .simultaneousGesture(
                     TapGesture().onEnded { isInputFocused = false }
@@ -97,7 +97,7 @@ public struct ChatHomeView: View {
                     .multilineTextAlignment(.center)
                     .frame(maxWidth: 318)
             }
-            .padding(.top, 49)
+            .padding(.top, 22)
             .simultaneousGesture(
                 TapGesture().onEnded { isInputFocused = false }
             )
@@ -114,7 +114,7 @@ public struct ChatHomeView: View {
                 }
             }
             .padding(.horizontal, 24)
-            .padding(.top, 70)
+            .padding(.top, 40)
             .simultaneousGesture(
                 TapGesture().onEnded { isInputFocused = false }
             )

--- a/Sources/HopesDesignSystem/Screens/OnboardingView.swift
+++ b/Sources/HopesDesignSystem/Screens/OnboardingView.swift
@@ -27,7 +27,7 @@ public struct OnboardingView: View {
                     .foregroundStyle(.white)
                     .lineSpacing(3)
                     .padding(.horizontal, 32)
-                    .padding(.top, 88)
+                    .padding(.top, 48)
 
                 Text("질문에 학년, 관심 전공, 상황을 같이 적으면 더 현실적인 답변을 받을 수 있어요.")
                     .font(.system(size: 16, weight: .medium))
@@ -51,7 +51,7 @@ public struct OnboardingView: View {
                     )
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.top, 56)
+                .padding(.top, 40)
 
                 HopesButton(
                     "채팅 시작하기",


### PR DESCRIPTION
## 📌 변경사항
- 채팅 홈 초기 배치를 피그마 기준으로 조정
- 온보딩 시작 위치를 위로 조정
- 탭바 높이를 56pt로 정리하고 기종별 Safe Area 대응

## 📷 스크린샷
- 시뮬레이터에서 iPhone 17 Pro 기준 확인

## 🔗 관련 이슈
close #199

## 💬 참고사항
- .DS_Store는 커밋에서 제외
- xcodebuild 빌드 성공