### PR TITLE
Fix 테스트 중 발견된 탭바 및 계정 정보 오류 수정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
+++ b/Sources/HopesDesignSystem/Screens/AccountInfoView.swift
@@ -9,33 +9,23 @@ public struct AccountInfoView: View {
     private let isSchoolVerified: Bool
     private let onBack: () -> Void
     private let onDone: () -> Void
-    private let isDeletingAccount: Bool
-    private let accountDeletionErrorMessage: String?
-    private let onDeleteAccount: (String) -> Void
     private let onSelectTab: (HopesTab) -> Void
-    @State private var isDeletionSheetPresented = false
 
     public init(
         email: String = "s26055@gsm.hs.kr",
         major: String = "인공지능소프트웨어과",
         cohort: String = "10기",
         isSchoolVerified: Bool = true,
-        isDeletingAccount: Bool = false,
-        accountDeletionErrorMessage: String? = nil,
         onBack: @escaping () -> Void = {},
         onDone: @escaping () -> Void = {},
-        onDeleteAccount: @escaping (String) -> Void = { _ in },
         onSelectTab: @escaping (HopesTab) -> Void = { _ in }
     ) {
         self.email = email
         self.major = major
         self.cohort = cohort
         self.isSchoolVerified = isSchoolVerified
-        self.isDeletingAccount = isDeletingAccount
-        self.accountDeletionErrorMessage = accountDeletionErrorMessage
         self.onBack = onBack
         self.onDone = onDone
-        self.onDeleteAccount = onDeleteAccount
         self.onSelectTab = onSelectTab
     }
 
@@ -47,14 +37,6 @@ public struct AccountInfoView: View {
 
                 accountCard
                     .padding(.top, 32)
-
-                HopesButton(
-                    "회원탈퇴",
-                    variant: .danger,
-                    width: .fill,
-                    action: { isDeletionSheetPresented = true }
-                )
-                .padding(.top, 30)
             }
             .padding(.horizontal, HopesMetrics.screenHorizontalPadding)
             .padding(.bottom, 24)
@@ -63,17 +45,6 @@ public struct AccountInfoView: View {
         .background(Color.hopesBackground.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
             HopesTabBar(selection: $selectedTab, onSelect: onSelectTab)
-        }
-        .sheet(isPresented: $isDeletionSheetPresented) {
-            AccountDeletionView(
-                isDeleting: isDeletingAccount,
-                errorMessage: accountDeletionErrorMessage,
-                onCancel: { isDeletionSheetPresented = false },
-                onContinue: onDeleteAccount
-            )
-            .presentationDetents([.medium])
-            .presentationDragIndicator(.visible)
-            .interactiveDismissDisabled(isDeletingAccount)
         }
     }
 

--- a/Sources/HopesDesignSystem/Screens/ContactView.swift
+++ b/Sources/HopesDesignSystem/Screens/ContactView.swift
@@ -64,9 +64,11 @@ public struct ContactView: View {
         )
         .background(Color.hopesBackground.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            HopesTabBar(selection: $selectedTab) { tab in
-                focusedField = nil
-                onSelectTab(tab)
+            if focusedField == nil {
+                HopesTabBar(selection: $selectedTab) { tab in
+                    focusedField = nil
+                    onSelectTab(tab)
+                }
             }
         }
     }

--- a/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
+++ b/Sources/HopesDesignSystem/Screens/ConversationHistoryView.swift
@@ -82,9 +82,11 @@ public struct ConversationHistoryView: View {
         )
         .background(Color.hopesBackground.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            HopesTabBar(selection: $selectedTab) { tab in
-                isSearchFocused = false
-                onSelectTab(tab)
+            if !isSearchFocused {
+                HopesTabBar(selection: $selectedTab) { tab in
+                    isSearchFocused = false
+                    onSelectTab(tab)
+                }
             }
         }
     }

--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -357,15 +357,12 @@ public struct LoginFlowView: View {
                     email: profileEmail,
                     major: profileMajor,
                     cohort: profileCohort,
-                    isDeletingAccount: isDeletingAccount,
-                    accountDeletionErrorMessage: accountDeletionErrorMessage,
                     onBack: {
                         transition(to: .myPage)
                     },
                     onDone: {
                         transition(to: .myPage)
                     },
-                    onDeleteAccount: deleteAccount,
                     onSelectTab: navigateFromTab
                 )
                     .transition(.opacity)

--- a/Sources/HopesDesignSystem/Screens/MyPageView.swift
+++ b/Sources/HopesDesignSystem/Screens/MyPageView.swift
@@ -132,9 +132,11 @@ public struct MyPageView: View {
             including: .gesture
         )
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            HopesTabBar(selection: $selectedTab) { tab in
-                focusedField = nil
-                onSelectTab(tab)
+            if focusedField == nil {
+                HopesTabBar(selection: $selectedTab) { tab in
+                    focusedField = nil
+                    onSelectTab(tab)
+                }
             }
         }
         .background(Color.hopesBackground.ignoresSafeArea())
@@ -212,7 +214,7 @@ public struct MyPageView: View {
         }
         .padding(.horizontal, cardContentHorizontalPadding)
         .padding(.vertical, 24)
-        .frame(width: 354, height: 326, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 326, maxHeight: 326, alignment: .topLeading)
         .background(.white)
         .clipShape(
             RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)
@@ -266,7 +268,7 @@ public struct MyPageView: View {
         .foregroundStyle(Color.hopesTextPrimary)
         .padding(.horizontal, cardContentHorizontalPadding)
         .padding(.vertical, 24)
-        .frame(width: 354, height: 128, alignment: .topLeading)
+        .frame(maxWidth: .infinity, minHeight: 128, maxHeight: 128, alignment: .topLeading)
         .background(.white)
         .clipShape(
             RoundedRectangle(cornerRadius: HopesMetrics.cardCornerRadius)

--- a/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
+++ b/Sources/HopesDesignSystem/Screens/PersonalSettingsView.swift
@@ -60,9 +60,11 @@ public struct PersonalSettingsView: View {
         )
         .background(Color.hopesBackground.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            HopesTabBar(selection: $selectedTab) { tab in
-                focusedField = nil
-                onSelectTab(tab)
+            if focusedField == nil {
+                HopesTabBar(selection: $selectedTab) { tab in
+                    focusedField = nil
+                    onSelectTab(tab)
+                }
             }
         }
     }


### PR DESCRIPTION
## 📌 변경사항
- 키보드 표시 시 하단 탭바가 올라오는 문제 수정
- 기기별 마이페이지 카드 폭 대응
- 계정 정보 화면 회원탈퇴 UI 제거
- 관련 호출부 정리

## 📷 스크린샷
- iPhone 시뮬레이터 5종 레이아웃 확인

## 🔗 관련 이슈
close #201

## 💬 참고사항
- xcodebuild 빌드 성공
- .DS_Store는 커밋에서 제외
- 머지는 대기