### PR TITLE
chore:[#205] 제목 크기 24 -> 에서 20으로 조정

### DIFF
--- a/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
+++ b/Sources/HopesDesignSystem/Screens/ChatDetailView.swift
@@ -98,7 +98,7 @@ public struct ChatDetailView: View {
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
-                    .font(.system(size: 24, weight: .bold))
+                    .font(.system(size: 20, weight: .bold))
                     .foregroundStyle(Color.hopesTextPrimary)
                     .lineLimit(1)
                 Text("홉스 AI 답변")


### PR DESCRIPTION
## 📌 변경사항
채팅에서 뜨는 상단 제목을 24 에서 20 으로 조정했습니다


## 📷 스크린샷
<img width="441" height="940" alt="스크린샷 2026-09-02 오전 8 09 05" src="https://github.com/user-attachments/assets/35c1315e-a1a5-4461-b9d0-72393059f544" />



## 🔗 관련 이슈

close #205 

## 💬 참고사항
없음

