### PR TITLE
fix: 채팅 탭 이동 시 진행 중인 대화 유지

### DIFF
--- a/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
+++ b/Sources/HopesDesignSystem/Screens/LoginFlowView.swift
@@ -57,6 +57,7 @@ public struct LoginFlowView: View {
     @State private var conversationErrorMessage: String?
     @State private var selectedConversationID: Int64?
     @State private var activeChat: ChatResponse?
+    @State private var shouldRestoreActiveChat = false
     @State private var isLoadingChat = false
     @State private var isSendingMessage = false
     @State private var chatErrorMessage: String?
@@ -199,6 +200,7 @@ public struct LoginFlowView: View {
                     isSending: isSendingMessage,
                     errorMessage: chatErrorMessage,
                     onBack: {
+                        shouldRestoreActiveChat = false
                         transition(to: .chatHome)
                     },
                     onShowSources: {
@@ -235,6 +237,7 @@ public struct LoginFlowView: View {
                     },
                     onSelectConversation: { conversation in
                         selectedConversationID = conversation.id
+                        shouldRestoreActiveChat = true
                         transition(to: .chatDetail)
                         loadChat(id: conversation.id)
                     },
@@ -740,6 +743,7 @@ public struct LoginFlowView: View {
         isLoadingChat = true
         chatErrorMessage = nil
         activeChat = nil
+        shouldRestoreActiveChat = true
         transition(to: .chatDetail)
         Task {
             do {
@@ -854,7 +858,12 @@ public struct LoginFlowView: View {
         case .home:
             transition(to: .onboarding)
         case .chat:
-            transition(to: .chatHome)
+            if shouldRestoreActiveChat,
+               activeChat != nil || selectedConversationID != nil || isLoadingChat {
+                transition(to: .chatDetail)
+            } else {
+                transition(to: .chatHome)
+            }
         case .history:
             transition(to: .conversationHistory)
         case .settings:


### PR DESCRIPTION
## 변경 사항
- 진행 중인 대화에서 다른 탭으로 이동한 뒤 채팅 탭을 선택하면 기존 대화 상세 화면으로 복귀합니다.
- 대화 상세의 뒤로가기 버튼을 누른 경우에만 채팅 홈으로 돌아갑니다.

## 검증
- iOS Simulator 빌드 성공

## 관련 이슈
- #210